### PR TITLE
Remove cropper step when adding attachments

### DIFF
--- a/App/Views/Shared/ImagePickerFlowView.swift
+++ b/App/Views/Shared/ImagePickerFlowView.swift
@@ -13,33 +13,16 @@ struct ImagePickerFlowView: View {
     let onComplete: (UIImage) -> Void
     let onCancel: () -> Void
 
-    @State private var selectedPhotoItem: PhotosPickerItem?
-    @State private var pickedImage: UIImage?
-
     var body: some View {
-        Group {
-            if let pickedImage {
-                ImageCropView(
-                    image: pickedImage,
-                    onCrop: { croppedImage in
-                        onComplete(croppedImage)
-                    },
-                    onCancel: {
-                        onCancel()
-                    }
-                )
-            } else {
-                PhotoPickerRepresentable(
-                    onPick: { image in
-                        pickedImage = image
-                    },
-                    onCancel: {
-                        onCancel()
-                    }
-                )
-                .ignoresSafeArea()
+        PhotoPickerRepresentable(
+            onPick: { image in
+                onComplete(image)
+            },
+            onCancel: {
+                onCancel()
             }
-        }
+        )
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
The image picker flow now passes the selected photo directly to the
attachment without showing the crop view in between.

https://claude.ai/code/session_012qeKdwNe7kBVENFdE3Ee6L