### PR TITLE
Add localized strings and improve image crop & attachment UI

### DIFF
--- a/App/Localizable.xcstrings
+++ b/App/Localizable.xcstrings
@@ -452,10 +452,72 @@
       }
     },
     "Buys.NoAttachments" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Attachments"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添付ファイルがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첨부파일 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有附件"
+          }
+        }
+      }
     },
     "Buys.NoAttachments.Description" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add attachments to this circle first, then select one as the item image."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "先にこのサークルに添付ファイルを追加してから、アイテム画像として選択してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "먼저 이 서클에 첨부파일을 추가한 후 아이템 이미지로 선택하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先为此社团添加附件，然后选择一个作为物品图片。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先為此社團新增附件，然後選擇一個作為物品圖片。"
+          }
+        }
+      }
     },
     "Buys.NoBuys" : {
       "localizations" : {
@@ -560,7 +622,38 @@
       }
     },
     "Buys.SelectFromAttachments" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select from Attachments"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添付ファイルから選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첨부파일에서 선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从附件中选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從附件中選擇"
+          }
+        }
+      }
     },
     "Buys.SelectImage" : {
       "localizations" : {
@@ -7827,6 +7920,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下午入場"
+          }
+        }
+      }
+    },
+    "Tip.AttachmentAndBuys.Description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add photos of product lists as attachments, then track individual items you want to buy in the Buys section."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お品書きの写真を添付ファイルとして追加し、宝物セクションで購入予定のアイテムを管理できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상품 목록 사진을 첨부파일로 추가한 후, 구매 목록 섹션에서 구매할 아이템을 관리하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将商品列表的照片添加为附件，然后在宝贝区域中跟踪您想购买的物品。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將商品列表的照片新增為附件，然後在寶藏區域中追蹤您想購買的物品。"
+          }
+        }
+      }
+    },
+    "Tip.AttachmentAndBuys.Title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attachments & Buys"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添付ファイルと宝物"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첨부파일 및 구매 목록"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件与宝贝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件與寶藏"
           }
         }
       }

--- a/App/Structs/Tips/AttachmentAndBuysTip.swift
+++ b/App/Structs/Tips/AttachmentAndBuysTip.swift
@@ -1,0 +1,21 @@
+//
+//  AttachmentAndBuysTip.swift
+//  CiRCLES
+//
+//  Created by Claude on 2026/03/28.
+//
+
+import Foundation
+import TipKit
+
+struct AttachmentAndBuysTip: Tip {
+    var title: Text {
+        Text("Tip.AttachmentAndBuys.Title")
+    }
+    var message: Text? {
+        Text("Tip.AttachmentAndBuys.Description")
+    }
+    var image: Image? {
+        Image(systemName: "photo.on.rectangle.angled")
+    }
+}

--- a/App/Views/Shared/AttachmentPickerView.swift
+++ b/App/Views/Shared/AttachmentPickerView.swift
@@ -45,7 +45,8 @@ struct AttachmentPickerView: View {
                                         Image(uiImage: image)
                                             .resizable()
                                             .scaledToFill()
-                                            .frame(minHeight: 120.0)
+                                            .frame(width: 120.0, height: 120.0)
+                                            .clipped()
                                             .clipShape(RoundedRectangle(cornerRadius: 8.0))
                                     }
                                 }
@@ -59,8 +60,14 @@ struct AttachmentPickerView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Shared.Cancel") {
-                        onCancel()
+                    if #available(iOS 26.0, *) {
+                        Button(role: .cancel) {
+                            onCancel()
+                        }
+                    } else {
+                        Button("Shared.Cancel") {
+                            onCancel()
+                        }
                     }
                 }
             }

--- a/App/Views/Shared/Circle Detail/CircleDetailBuysSection.swift
+++ b/App/Views/Shared/Circle Detail/CircleDetailBuysSection.swift
@@ -164,11 +164,12 @@ struct CircleDetailBuysSection: View {
             .frame(width: 70.0)
             .multilineTextAlignment(.trailing)
             .foregroundStyle(.secondary)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
                 deleteItem(id: item.id)
             } label: {
-                Image(systemName: "trash")
-                    .font(.caption)
+                Label("Shared.Delete", systemImage: "trash")
             }
         }
     }

--- a/App/Views/Shared/Circle Detail/CircleDetailView.swift
+++ b/App/Views/Shared/Circle Detail/CircleDetailView.swift
@@ -8,6 +8,7 @@
 import Komponents
 import SwiftData
 import SwiftUI
+import TipKit
 import Translation
 import UIKit
 import RADiUS
@@ -228,6 +229,7 @@ struct CircleDetailView: View {
                 } label: {
                     Label("Circles.Attachments.Add", systemImage: "plus.circle.fill")
                 }
+                .popoverTip(AttachmentAndBuysTip())
             }
         case .buys:
             CircleDetailBuysSection(

--- a/App/Views/Shared/ImageCropView.swift
+++ b/App/Views/Shared/ImageCropView.swift
@@ -34,18 +34,21 @@ struct ImageCropView: View {
                             SimultaneousGesture(
                                 MagnifyGesture()
                                     .onChanged { value in
-                                        scale = lastScale * value.magnification
+                                        scale = max(1.0, lastScale * value.magnification)
                                     }
                                     .onEnded { _ in
                                         lastScale = max(1.0, scale)
                                         scale = lastScale
+                                        offset = clampedOffset(offset, viewSize: geometry.size, cropSize: cropSize)
+                                        lastOffset = offset
                                     },
                                 DragGesture()
                                     .onChanged { value in
-                                        offset = CGSize(
+                                        let proposed = CGSize(
                                             width: lastOffset.width + value.translation.width,
                                             height: lastOffset.height + value.translation.height
                                         )
+                                        offset = clampedOffset(proposed, viewSize: geometry.size, cropSize: cropSize)
                                     }
                                     .onEnded { _ in
                                         lastOffset = offset
@@ -79,8 +82,14 @@ struct ImageCropView: View {
             .ignoresSafeArea()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Shared.Cancel") {
-                        onCancel()
+                    if #available(iOS 26.0, *) {
+                        Button(role: .cancel) {
+                            onCancel()
+                        }
+                    } else {
+                        Button("Shared.Cancel") {
+                            onCancel()
+                        }
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
@@ -91,6 +100,33 @@ struct ImageCropView: View {
             }
             .toolbarBackground(.hidden, for: .navigationBar)
         }
+    }
+
+    private func clampedOffset(_ proposed: CGSize, viewSize: CGSize, cropSize: CGFloat) -> CGSize {
+        let imageAspect = image.size.width / image.size.height
+        let viewAspect = viewSize.width / viewSize.height
+
+        let fittedSize: CGSize
+        if imageAspect > viewAspect {
+            let width = viewSize.width
+            let height = width / imageAspect
+            fittedSize = CGSize(width: width, height: height)
+        } else {
+            let height = viewSize.height
+            let width = height * imageAspect
+            fittedSize = CGSize(width: width, height: height)
+        }
+
+        let scaledWidth = fittedSize.width * scale
+        let scaledHeight = fittedSize.height * scale
+
+        let maxOffsetX = max(0, (scaledWidth - cropSize) / 2.0)
+        let maxOffsetY = max(0, (scaledHeight - cropSize) / 2.0)
+
+        return CGSize(
+            width: min(maxOffsetX, max(-maxOffsetX, proposed.width)),
+            height: min(maxOffsetY, max(-maxOffsetY, proposed.height))
+        )
     }
 
     private func cropImage() {


### PR DESCRIPTION
## Summary
This PR adds comprehensive localization support for attachment and purchase-related features, improves the image cropping experience with better offset clamping, and refines the UI for attachment selection and purchase item management.

## Key Changes

### Localization Additions
- Added translations for `Buys.NoAttachments`, `Buys.NoAttachments.Description`, and `Buys.SelectFromAttachments` strings across 5 languages (English, Japanese, Korean, Simplified Chinese, Traditional Chinese)
- Added new tip strings `Tip.AttachmentAndBuys.Title` and `Tip.AttachmentAndBuys.Description` with full localization support
- Created new `AttachmentAndBuysTip.swift` struct to display tips about using attachments with the Buys feature

### Image Crop View Improvements
- Enhanced `ImageCropView.swift` with proper offset clamping to prevent the image from being dragged outside the crop area
- Added `clampedOffset()` function that calculates maximum allowed offsets based on image aspect ratio, view size, and current scale
- Fixed magnification gesture to maintain minimum scale of 1.0
- Added iOS 26.0+ compatibility for cancel button with proper role assignment

### Attachment & Purchase UI Refinements
- Updated `AttachmentPickerView.swift` to use fixed 120x120 frame with clipping for consistent thumbnail display
- Added iOS 26.0+ compatibility for cancel button in attachment picker
- Improved `CircleDetailBuysSection.swift` by moving delete button to swipe actions (trailing edge) with proper label instead of icon-only button
- Enhanced visual consistency and accessibility with labeled delete action

### Implementation Details
- The clamped offset calculation accounts for image aspect ratio fitting within the view and applies scale transformations
- Swipe actions provide a more intuitive deletion experience compared to inline buttons
- Conditional availability checks ensure compatibility across iOS versions while using modern APIs when available

https://claude.ai/code/session_01CNTDJEFw25W5Q8bm38XFHk