### PR TITLE
Overhaul for speed, battery, and offline/network reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata/
 **/OpenID.plist
+**/xcshareddata/xcodecloud/

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -193,7 +193,7 @@ extension Database {
     // MARK: Indexing
 
     public func prepareIndexes(for event: WebCatalogEvent.Response.Event) async {
-        let flagKey = "Database.Indexed.\(event.number)"
+        let flagKey = Database.indexedFlagKey(forEvent: event.number)
         if UserDefaults.standard.bool(forKey: flagKey) { return }
         let textPath = textDatabaseURL?.path(percentEncoded: false)
         let imagePath = imageDatabaseURL?.path(percentEncoded: false)

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -235,12 +235,22 @@ extension Database {
             try? database.execute(statement)
         }
 
-        let rawCount = try? database.scalar(
-            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='CircleSearchFTS'"
-        )
-        let ftsExists = ((rawCount ?? nil) as? Int64) ?? 0
-        if ftsExists == 0 {
-            do {
+        Self.buildSearchIndex(in: database)
+        return true
+    }
+
+    private nonisolated static func buildSearchIndex(in database: Connection) {
+        let sourceCount = Self.rowCount(in: database, of: "ComiketCircleWC")
+        if Self.tableExists("CircleSearchFTS", in: database) {
+            // A table left empty by an interrupted build silently breaks search,
+            // since ftsSearch then returns [] instead of falling back to LIKE.
+            if Self.rowCount(in: database, of: "CircleSearchFTS") == sourceCount {
+                return
+            }
+            try? database.execute("DROP TABLE IF EXISTS CircleSearchFTS")
+        }
+        do {
+            try database.transaction {
                 try database.run(
                     """
                     CREATE VIRTUAL TABLE CircleSearchFTS USING fts5(
@@ -255,11 +265,22 @@ extension Database {
                     SELECT id, circleName, circleKana, penName FROM ComiketCircleWC
                     """
                 )
-            } catch {
-                try? database.execute("DROP TABLE IF EXISTS CircleSearchFTS")
             }
+        } catch {
+            try? database.execute("DROP TABLE IF EXISTS CircleSearchFTS")
         }
-        return true
+    }
+
+    private nonisolated static func tableExists(_ name: String, in database: Connection) -> Bool {
+        let rawCount = try? database.scalar(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", name
+        )
+        return (((rawCount ?? nil) as? Int64) ?? 0) > 0
+    }
+
+    private nonisolated static func rowCount(in database: Connection, of table: String) -> Int64 {
+        let rawCount = try? database.scalar("SELECT count(*) FROM \"\(table)\"")
+        return ((rawCount ?? nil) as? Int64) ?? -1
     }
 
 }

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -115,7 +115,7 @@ extension Database {
 
         var totalSize: Int64 = 0
         for url in urls {
-            var headRequest = URLRequest(url: url)
+            var headRequest = URLRequest(url: url, timeoutInterval: circleMsHeadTimeout)
             headRequest.httpMethod = "HEAD"
             if let (_, response) = try? await URLSession.shared.data(for: headRequest),
                let httpResponse = response as? HTTPURLResponse,
@@ -182,7 +182,7 @@ extension Database {
     public func urlRequestForWebCatalogAPI(_ endpoint: String, authToken: OpenIDToken) -> URLRequest {
         let endpoint = URL(string: "\(circleMsAPIEndpoint)/CatalogBase/\(endpoint)/")!
 
-        var request = URLRequest(url: endpoint)
+        var request = URLRequest(url: endpoint, timeoutInterval: circleMsAPITimeout)
         request.httpMethod = "POST"
         request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
 

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -6,6 +6,7 @@
 //
 
 import RADiUS
+import SQLite
 import UIKit
 import ZIPFoundation
 
@@ -187,6 +188,72 @@ extension Database {
         request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
 
         return request
+    }
+
+    // MARK: Indexing
+
+    // One-time, idempotent: builds secondary indexes on the hot filter columns and an FTS5 trigram
+    // table for circle search. The catalog DB ships without these, so every filter is otherwise a
+    // full table scan and search is a triple leading-wildcard LIKE. Runs once per event (gated by a
+    // flag) on a background connection so it never blocks the main thread.
+    public func prepareIndexes(for event: WebCatalogEvent.Response.Event) async {
+        let flagKey = "Database.Indexed.\(event.number)"
+        if UserDefaults.standard.bool(forKey: flagKey) { return }
+        guard let textDatabaseURL else { return }
+        let path = textDatabaseURL.path(percentEncoded: false)
+        let didBuild = await Task.detached(priority: .userInitiated) {
+            Self.buildIndexes(atPath: path)
+        }.value
+        if didBuild {
+            UserDefaults.standard.set(true, forKey: flagKey)
+        }
+    }
+
+    private nonisolated static func buildIndexes(atPath path: String) -> Bool {
+        guard let database = try? Connection(path, readonly: false) else { return false }
+        let indexStatements = [
+            "CREATE INDEX IF NOT EXISTS idx_circlewc_block ON ComiketCircleWC(blockId)",
+            "CREATE INDEX IF NOT EXISTS idx_circlewc_genre ON ComiketCircleWC(genreId)",
+            "CREATE INDEX IF NOT EXISTS idx_circlewc_day ON ComiketCircleWC(day)",
+            "CREATE INDEX IF NOT EXISTS idx_circlewc_day_block ON ComiketCircleWC(day, blockId)",
+            "CREATE INDEX IF NOT EXISTS idx_extend_wcid ON ComiketCircleExtend(WCId)",
+            "CREATE INDEX IF NOT EXISTS idx_mapping_map ON ComiketMappingWC(mapId)",
+            "CREATE INDEX IF NOT EXISTS idx_mapping_block ON ComiketMappingWC(blockId)",
+            "CREATE INDEX IF NOT EXISTS idx_layout_map ON ComiketLayoutWC(mapId)"
+        ]
+        // Each statement is isolated so one missing column can't abort the rest.
+        for statement in indexStatements {
+            try? database.run(statement)
+        }
+
+        // FTS5 trigram for substring search. Best-effort: if the tokenizer is unavailable the
+        // search path falls back to LIKE, so failure here is non-fatal.
+        let rawCount = try? database.scalar(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='CircleSearchFTS'"
+        )
+        let ftsExists = ((rawCount ?? nil) as? Int64) ?? 0
+        if ftsExists == 0 {
+            do {
+                try database.run(
+                    """
+                    CREATE VIRTUAL TABLE CircleSearchFTS USING fts5(
+                        circleName, circleKana, penName,
+                        content='ComiketCircleWC', content_rowid='id', tokenize='trigram'
+                    )
+                    """
+                )
+                try database.run(
+                    """
+                    INSERT INTO CircleSearchFTS(rowid, circleName, circleKana, penName)
+                    SELECT id, circleName, circleKana, penName FROM ComiketCircleWC
+                    """
+                )
+            } catch {
+                // Leave no half-built table behind: drop it so search cleanly falls back to LIKE.
+                try? database.run("DROP TABLE IF EXISTS CircleSearchFTS")
+            }
+        }
+        return true
     }
 
 }

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -199,14 +199,30 @@ extension Database {
     public func prepareIndexes(for event: WebCatalogEvent.Response.Event) async {
         let flagKey = "Database.Indexed.\(event.number)"
         if UserDefaults.standard.bool(forKey: flagKey) { return }
-        guard let textDatabaseURL else { return }
-        let path = textDatabaseURL.path(percentEncoded: false)
+        let textPath = textDatabaseURL?.path(percentEncoded: false)
+        let imagePath = imageDatabaseURL?.path(percentEncoded: false)
         let didBuild = await Task.detached(priority: .userInitiated) {
-            Self.buildIndexes(atPath: path)
+            var builtText = false
+            if let textPath {
+                builtText = Self.buildIndexes(atPath: textPath)
+            }
+            if let imagePath {
+                _ = Self.buildImageIndexes(atPath: imagePath)
+            }
+            return builtText
         }.value
         if didBuild {
             UserDefaults.standard.set(true, forKey: flagKey)
         }
+    }
+
+    // Guarantees the lazy per-id / per-name image lookups are indexed lookups rather than full
+    // scans (harmless no-op if the columns are already primary keys).
+    private nonisolated static func buildImageIndexes(atPath path: String) -> Bool {
+        guard let database = try? Connection(path, readonly: false) else { return false }
+        try? database.run("CREATE INDEX IF NOT EXISTS idx_circleimage_id ON ComiketCircleImage(id)")
+        try? database.run("CREATE INDEX IF NOT EXISTS idx_commonimage_name ON ComiketCommonImage(name)")
+        return true
     }
 
     private nonisolated static func buildIndexes(atPath path: String) -> Bool {

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -198,14 +198,14 @@ extension Database {
         let textPath = textDatabaseURL?.path(percentEncoded: false)
         let imagePath = imageDatabaseURL?.path(percentEncoded: false)
         let didBuild = await Task.detached(priority: .userInitiated) {
-            var builtText = false
+            var success = true
             if let textPath {
-                builtText = Self.buildIndexes(atPath: textPath)
+                success = Self.buildIndexes(atPath: textPath) && success
             }
             if let imagePath {
-                _ = Self.buildImageIndexes(atPath: imagePath)
+                success = Self.buildImageIndexes(atPath: imagePath) && success
             }
-            return builtText
+            return success
         }.value
         if didBuild {
             UserDefaults.standard.set(true, forKey: flagKey)

--- a/AXiS/Database+Download.swift
+++ b/AXiS/Database+Download.swift
@@ -192,10 +192,6 @@ extension Database {
 
     // MARK: Indexing
 
-    // One-time, idempotent: builds secondary indexes on the hot filter columns and an FTS5 trigram
-    // table for circle search. The catalog DB ships without these, so every filter is otherwise a
-    // full table scan and search is a triple leading-wildcard LIKE. Runs once per event (gated by a
-    // flag) on a background connection so it never blocks the main thread.
     public func prepareIndexes(for event: WebCatalogEvent.Response.Event) async {
         let flagKey = "Database.Indexed.\(event.number)"
         if UserDefaults.standard.bool(forKey: flagKey) { return }
@@ -216,12 +212,10 @@ extension Database {
         }
     }
 
-    // Guarantees the lazy per-id / per-name image lookups are indexed lookups rather than full
-    // scans (harmless no-op if the columns are already primary keys).
     private nonisolated static func buildImageIndexes(atPath path: String) -> Bool {
         guard let database = try? Connection(path, readonly: false) else { return false }
-        try? database.run("CREATE INDEX IF NOT EXISTS idx_circleimage_id ON ComiketCircleImage(id)")
-        try? database.run("CREATE INDEX IF NOT EXISTS idx_commonimage_name ON ComiketCommonImage(name)")
+        try? database.execute("CREATE INDEX IF NOT EXISTS idx_circleimage_id ON ComiketCircleImage(id)")
+        try? database.execute("CREATE INDEX IF NOT EXISTS idx_commonimage_name ON ComiketCommonImage(name)")
         return true
     }
 
@@ -237,13 +231,10 @@ extension Database {
             "CREATE INDEX IF NOT EXISTS idx_mapping_block ON ComiketMappingWC(blockId)",
             "CREATE INDEX IF NOT EXISTS idx_layout_map ON ComiketLayoutWC(mapId)"
         ]
-        // Each statement is isolated so one missing column can't abort the rest.
         for statement in indexStatements {
-            try? database.run(statement)
+            try? database.execute(statement)
         }
 
-        // FTS5 trigram for substring search. Best-effort: if the tokenizer is unavailable the
-        // search path falls back to LIKE, so failure here is non-fatal.
         let rawCount = try? database.scalar(
             "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='CircleSearchFTS'"
         )
@@ -265,8 +256,7 @@ extension Database {
                     """
                 )
             } catch {
-                // Leave no half-built table behind: drop it so search cleanly falls back to LIKE.
-                try? database.run("DROP TABLE IF EXISTS CircleSearchFTS")
+                try? database.execute("DROP TABLE IF EXISTS CircleSearchFTS")
             }
         }
         return true

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -186,8 +186,7 @@ extension Database {
         if let cachedImage = cachedDecodedImage(key) {
             return cachedImage
         }
-        guard commonImageNames.contains(imageName),
-              let imageDatabase = getImageDatabase(),
+        guard let imageDatabase = getImageDatabase(),
               let imageData = Database.readCommonImageData(from: imageDatabase, name: imageName),
               let image = UIImage(data: imageData) else {
             return nil

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -24,7 +24,10 @@ extension Database {
                     on: circlesTable[id] == circleExtendedInformationTable[id]
                 )
 
-                let query = joinedTable.filter(identifiers.contains(circlesTable[id]))
+                // Order in SQL (PK) so we don't sort the hydrated array in Swift on the main actor.
+                let query = joinedTable
+                    .filter(identifiers.contains(circlesTable[id]))
+                    .order(reversed ? circlesTable[id].desc : circlesTable[id].asc)
                 let circles = try textDatabase.prepare(query).map { row in
                     let circle = ComiketCircle(from: row)
                     let extendedInformation = ComiketCircleExtendedInformation(from: row)
@@ -46,11 +49,7 @@ extension Database {
                     }
                 }
 
-                if reversed {
-                    return circles.sorted(by: { $0.id > $1.id })
-                } else {
-                    return circles.sorted(by: { $0.id < $1.id })
-                }
+                return circles
             } catch {
                 debugPrint(error.localizedDescription)
             }

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -151,6 +151,36 @@ extension Database {
         return circleImage
     }
 
+    // Synchronous in-memory cache lookup only (no DB read). Lets cells render an already-decoded
+    // cut immediately without spawning a task.
+    public func cachedCircleImage(for id: Int) -> UIImage? {
+        cachedDecodedImage("circle:\(id)")
+    }
+
+    // Off-main variant for list/grid cells: the BLOB read and the (otherwise main-thread, at-draw)
+    // decode both happen on a background task so scrolling the catalog stays smooth. Returns cached
+    // results instantly on subsequent calls.
+    public func circleImageAsync(for id: Int) async -> UIImage? {
+        let key = "circle:\(id)"
+        if let cachedImage = cachedDecodedImage(key) {
+            return cachedImage
+        }
+        guard circleImageIDs.contains(id), let imageDatabase = getImageDatabase() else {
+            return nil
+        }
+        let decoded = await Task.detached(priority: .userInitiated) {
+            guard let data = Database.readCircleImageData(from: imageDatabase, id: id),
+                  let image = UIImage(data: data) else {
+                return nil as UIImage?
+            }
+            // Force-decode off the main thread so SwiftUI doesn't decode at draw time.
+            return image.preparingForDisplay() ?? image
+        }.value
+        guard let decoded else { return nil }
+        cacheDecodedImage(decoded, key: key, cost: decodedCost(of: decoded))
+        return decoded
+    }
+
     public func commonImage(named imageName: String) -> UIImage? {
         let key = "common:\(imageName)"
         if let cachedImage = cachedDecodedImage(key) {

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -138,26 +138,39 @@ extension Database {
     }
 
     public func circleImage(for id: Int) -> UIImage? {
-        if let cachedImage = imageCache[String(id)] {
+        let key = "circle:\(id)"
+        if let cachedImage = cachedDecodedImage(key) {
             return cachedImage
         }
-        if let circleImageData = circleImages[id] {
-            let circleImage = UIImage(data: circleImageData)
-            imageCache[String(id)] = circleImage
-            return circleImage
+        guard circleImageIDs.contains(id),
+              let imageDatabase = getImageDatabase(),
+              let circleImageData = Database.readCircleImageData(from: imageDatabase, id: id),
+              let circleImage = UIImage(data: circleImageData) else {
+            return nil
         }
-        return nil
+        cacheDecodedImage(circleImage, key: key, cost: decodedCost(of: circleImage))
+        return circleImage
     }
 
     public func commonImage(named imageName: String) -> UIImage? {
-        if let cachedImage = imageCache[imageName] {
+        let key = "common:\(imageName)"
+        if let cachedImage = cachedDecodedImage(key) {
             return cachedImage
         }
-        if let imageData = commonImages[imageName] {
-            let image = UIImage(data: imageData)
-            imageCache[imageName] = image
-            return image
+        guard commonImageNames.contains(imageName),
+              let imageDatabase = getImageDatabase(),
+              let imageData = Database.readCommonImageData(from: imageDatabase, name: imageName),
+              let image = UIImage(data: imageData) else {
+            return nil
         }
-        return nil
+        cacheDecodedImage(image, key: key, cost: decodedCost(of: image))
+        return image
+    }
+
+    private func decodedCost(of image: UIImage) -> Int {
+        if let cgImage = image.cgImage {
+            return cgImage.bytesPerRow * cgImage.height
+        }
+        return Int(image.size.width * image.size.height * 4.0)
     }
 }

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -24,7 +24,6 @@ extension Database {
                     on: circlesTable[id] == circleExtendedInformationTable[id]
                 )
 
-                // Order in SQL (PK) so we don't sort the hydrated array in Swift on the main actor.
                 let query = joinedTable
                     .filter(identifiers.contains(circlesTable[id]))
                     .order(reversed ? circlesTable[id].desc : circlesTable[id].asc)
@@ -151,15 +150,10 @@ extension Database {
         return circleImage
     }
 
-    // Synchronous in-memory cache lookup only (no DB read). Lets cells render an already-decoded
-    // cut immediately without spawning a task.
     public func cachedCircleImage(for id: Int) -> UIImage? {
         cachedDecodedImage("circle:\(id)")
     }
 
-    // Off-main variant for list/grid cells: the BLOB read and the (otherwise main-thread, at-draw)
-    // decode both happen on a background task so scrolling the catalog stays smooth. Returns cached
-    // results instantly on subsequent calls.
     public func circleImageAsync(for id: Int) async -> UIImage? {
         let key = "circle:\(id)"
         if let cachedImage = cachedDecodedImage(key) {
@@ -173,7 +167,6 @@ extension Database {
                   let image = UIImage(data: data) else {
                 return nil as UIImage?
             }
-            // Force-decode off the main thread so SwiftUI doesn't decode at draw time.
             return image.preparingForDisplay() ?? image
         }.value
         guard let decoded else { return nil }

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -135,6 +135,14 @@ extension Database {
         return commonImage(named: "\(usingHighDefinition ? "LWGR" : "WGR")\(day)\(hall.rawValue)")
     }
 
+    public func mapImageAsync(for hall: ComiketHall, on day: Int, usingHighDefinition: Bool) async -> UIImage? {
+        await commonImageAsync(named: "\(usingHighDefinition ? "LWMP" : "WMP")\(day)\(hall.rawValue)")
+    }
+
+    public func genreImageAsync(for hall: ComiketHall, on day: Int, usingHighDefinition: Bool) async -> UIImage? {
+        await commonImageAsync(named: "\(usingHighDefinition ? "LWGR" : "WGR")\(day)\(hall.rawValue)")
+    }
+
     public func circleImage(for id: Int) -> UIImage? {
         let key = "circle:\(id)"
         if let cachedImage = cachedDecodedImage(key) {
@@ -186,6 +194,24 @@ extension Database {
         }
         cacheDecodedImage(image, key: key, cost: decodedCost(of: image))
         return image
+    }
+
+    public func commonImageAsync(named imageName: String) async -> UIImage? {
+        let key = "common:\(imageName)"
+        if let cachedImage = cachedDecodedImage(key) {
+            return cachedImage
+        }
+        guard let imageDatabase = getImageDatabase() else { return nil }
+        let decoded = await Task.detached(priority: .userInitiated) {
+            guard let data = Database.readCommonImageData(from: imageDatabase, name: imageName),
+                  let image = UIImage(data: data) else {
+                return nil as UIImage?
+            }
+            return image.preparingForDisplay() ?? image
+        }.value
+        guard let decoded else { return nil }
+        cacheDecodedImage(decoded, key: key, cost: decodedCost(of: decoded))
+        return decoded
     }
 
     private func decodedCost(of image: UIImage) -> Int {

--- a/AXiS/Database+Fetchers.swift
+++ b/AXiS/Database+Fetchers.swift
@@ -143,21 +143,6 @@ extension Database {
         await commonImageAsync(named: "\(usingHighDefinition ? "LWGR" : "WGR")\(day)\(hall.rawValue)")
     }
 
-    public func circleImage(for id: Int) -> UIImage? {
-        let key = "circle:\(id)"
-        if let cachedImage = cachedDecodedImage(key) {
-            return cachedImage
-        }
-        guard circleImageIDs.contains(id),
-              let imageDatabase = getImageDatabase(),
-              let circleImageData = Database.readCircleImageData(from: imageDatabase, id: id),
-              let circleImage = UIImage(data: circleImageData) else {
-            return nil
-        }
-        cacheDecodedImage(circleImage, key: key, cost: decodedCost(of: circleImage))
-        return circleImage
-    }
-
     public func cachedCircleImage(for id: Int) -> UIImage? {
         cachedDecodedImage("circle:\(id)")
     }

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -20,10 +20,6 @@ public class Database {
     @ObservationIgnored public var imageDatabase: Connection?
     @ObservationIgnored public var textDatabaseURL: URL?
     @ObservationIgnored public var imageDatabaseURL: URL?
-    // Presence sets only — no image blobs are held in RAM. Blobs are read lazily per key when an
-    // image is actually displayed, and the decoded UIImages live in a bounded NSCache that evicts
-    // under memory pressure. This avoids loading tens of thousands of cut blobs at startup and the
-    // unbounded decoded-image growth that previously led to jetsam termination.
     @ObservationIgnored public var commonImageNames: Set<String> = []
     @ObservationIgnored public var circleImageIDs: Set<Int> = []
     @ObservationIgnored private let decodedImageCache: NSCache<NSString, UIImage> = {
@@ -44,7 +40,6 @@ public class Database {
         // No initialization required; properties are set lazily or by callers.
     }
 
-    // Bounded decoded-image cache accessors (the NSCache itself stays private to this file).
     func cachedDecodedImage(_ key: String) -> UIImage? {
         decodedImageCache.object(forKey: key as NSString)
     }
@@ -53,7 +48,6 @@ public class Database {
         decodedImageCache.setObject(image, forKey: key as NSString, cost: cost)
     }
 
-    // Clears decoded images held in RAM. On-disk blobs remain and are re-fetched lazily.
     public func clearDecodedImages() {
         decodedImageCache.removeAllObjects()
     }
@@ -85,8 +79,6 @@ public class Database {
         return imageDatabase
     }
 
-    // Tuning for read-only catalog connections: larger page cache + memory-mapped IO reduce
-    // page-read syscalls (fewer wakeups / less battery) on the large full-table reads and scans.
     private func applyReadOnlyPragmas(to connection: Connection?) {
         guard let connection else { return }
         try? connection.execute(
@@ -99,10 +91,6 @@ public class Database {
         )
     }
 
-    // A fresh, independent read-only connection to the text database. Lets concurrent readers
-    // (e.g. the catalog/search fetch) run in parallel instead of serializing behind heavy work
-    // on the shared connection (e.g. the map's layout query). The connection closes when its
-    // owning DataFetcher is released.
     public func newReadOnlyTextConnection() -> Connection? {
         guard let textDatabaseURL else { return nil }
         let connection = try? Connection(textDatabaseURL.path(percentEncoded: false), readonly: true)
@@ -251,7 +239,6 @@ public class Database {
         }
     }
 
-    // Presence sets are cheap to load (keys only, no blobs); they gate the lazy blob fetches below.
     private nonisolated static func readCommonImageNames(from imageDatabase: Connection) -> Set<String>? {
         do {
             let colName = Expression<String>("name")
@@ -274,8 +261,6 @@ public class Database {
         }
     }
 
-    // Lazy single-row blob reads (indexed primary-key / name lookups), used on demand by the
-    // image accessors in Database+Fetchers when a specific image is actually displayed.
     nonisolated static func readCircleImageData(from imageDatabase: Connection, id: Int) -> Data? {
         do {
             let colID = Expression<Int>("id")

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -40,6 +40,12 @@ public class Database {
         // No initialization required; properties are set lazily or by callers.
     }
 
+    static let indexedFlagKeyPrefix = "Database.Indexed."
+
+    static func indexedFlagKey(forEvent number: Int) -> String {
+        "\(indexedFlagKeyPrefix)\(number)"
+    }
+
     func cachedDecodedImage(_ key: String) -> UIImage? {
         decodedImageCache.object(forKey: key as NSString)
     }
@@ -170,6 +176,10 @@ public class Database {
             commonImageNames.removeAll()
             circleImageIDs.removeAll()
             decodedImageCache.removeAllObjects()
+            for key in UserDefaults.standard.dictionaryRepresentation().keys
+            where key.hasPrefix(Database.indexedFlagKeyPrefix) {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
             try? FileManager.default.removeItem(at: dataStoreURL)
         }
     }
@@ -193,6 +203,8 @@ public class Database {
                 circleImageIDs.removeAll()
                 decodedImageCache.removeAllObjects()
             }
+
+            UserDefaults.standard.removeObject(forKey: Database.indexedFlagKey(forEvent: event.number))
 
             try? FileManager.default.removeItem(at: targetTextDatabaseURL)
             try? FileManager.default.removeItem(at: targetImageDatabaseURL)

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -20,9 +20,17 @@ public class Database {
     @ObservationIgnored public var imageDatabase: Connection?
     @ObservationIgnored public var textDatabaseURL: URL?
     @ObservationIgnored public var imageDatabaseURL: URL?
-    @ObservationIgnored public var commonImages: [String: Data] = [:]
-    @ObservationIgnored public var circleImages: [Int: Data] = [:]
-    @ObservationIgnored public var imageCache: [String: UIImage] = [:]
+    // Presence sets only — no image blobs are held in RAM. Blobs are read lazily per key when an
+    // image is actually displayed, and the decoded UIImages live in a bounded NSCache that evicts
+    // under memory pressure. This avoids loading tens of thousands of cut blobs at startup and the
+    // unbounded decoded-image growth that previously led to jetsam termination.
+    @ObservationIgnored public var commonImageNames: Set<String> = []
+    @ObservationIgnored public var circleImageIDs: Set<Int> = []
+    @ObservationIgnored private let decodedImageCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.totalCostLimit = 64 * 1024 * 1024
+        return cache
+    }()
 
     public var commonImagesLoadCount: Int = 0
     public var circleImagesLoadCount: Int = 0
@@ -34,6 +42,24 @@ public class Database {
 
     public init() {
         // No initialization required; properties are set lazily or by callers.
+    }
+
+    // Bounded decoded-image cache accessors (the NSCache itself stays private to this file).
+    func cachedDecodedImage(_ key: String) -> UIImage? {
+        decodedImageCache.object(forKey: key as NSString)
+    }
+
+    func cacheDecodedImage(_ image: UIImage, key: String, cost: Int) {
+        decodedImageCache.setObject(image, forKey: key as NSString, cost: cost)
+    }
+
+    // Clears decoded images held in RAM. On-disk blobs remain and are re-fetched lazily.
+    public func clearDecodedImages() {
+        decodedImageCache.removeAllObjects()
+    }
+
+    public func hasCircleImage(_ id: Int) -> Bool {
+        circleImageIDs.contains(id)
     }
 
     // MARK: Database Connection
@@ -143,9 +169,9 @@ public class Database {
             databaseInformation = nil
             textDatabase = nil
             imageDatabase = nil
-            commonImages.removeAll()
-            circleImages.removeAll()
-            imageCache.removeAll()
+            commonImageNames.removeAll()
+            circleImageIDs.removeAll()
+            decodedImageCache.removeAllObjects()
             try? FileManager.default.removeItem(at: dataStoreURL)
         }
     }
@@ -165,9 +191,9 @@ public class Database {
             if imageDatabaseURL == targetImageDatabaseURL {
                 imageDatabase = nil
                 imageDatabaseURL = nil
-                commonImages.removeAll()
-                circleImages.removeAll()
-                imageCache.removeAll()
+                commonImageNames.removeAll()
+                circleImageIDs.removeAll()
+                decodedImageCache.removeAllObjects()
             }
 
             try? FileManager.default.removeItem(at: targetTextDatabaseURL)
@@ -186,9 +212,9 @@ public class Database {
         imageDatabaseURL = nil
         textDatabase = nil
         imageDatabase = nil
-        imageCache.removeAll()
-        commonImages.removeAll()
-        circleImages.removeAll()
+        decodedImageCache.removeAllObjects()
+        commonImageNames.removeAll()
+        circleImageIDs.removeAll()
     }
 
     // MARK: Loading
@@ -196,10 +222,10 @@ public class Database {
     public func loadCommonImages() async {
         guard let imageDatabase = getImageDatabase() else { return }
         let loaded = await Task.detached(priority: .userInitiated) {
-            Self.readCommonImages(from: imageDatabase)
+            Self.readCommonImageNames(from: imageDatabase)
         }.value
         if let loaded {
-            self.commonImages = loaded
+            self.commonImageNames = loaded
             self.commonImagesLoadCount += 1
         }
     }
@@ -207,36 +233,57 @@ public class Database {
     public func loadCircleImages() async {
         guard let imageDatabase = getImageDatabase() else { return }
         let loaded = await Task.detached(priority: .userInitiated) {
-            Self.readCircleImages(from: imageDatabase)
+            Self.readCircleImageIDs(from: imageDatabase)
         }.value
         if let loaded {
-            self.circleImages = loaded
+            self.circleImageIDs = loaded
             self.circleImagesLoadCount += 1
         }
     }
 
-    private nonisolated static func readCommonImages(from imageDatabase: Connection) -> [String: Data]? {
+    // Presence sets are cheap to load (keys only, no blobs); they gate the lazy blob fetches below.
+    private nonisolated static func readCommonImageNames(from imageDatabase: Connection) -> Set<String>? {
         do {
             let colName = Expression<String>("name")
-            let colImage = Expression<Data>("image")
-            let table = Table("ComiketCommonImage").select(colName, colImage)
-            return try imageDatabase.prepare(table).reduce(into: [:]) { partialResult, row in
-                partialResult[row[colName]] = row[colImage]
-            }
+            let table = Table("ComiketCommonImage").select(colName)
+            return try Set(imageDatabase.prepare(table).map { $0[colName] })
         } catch {
             debugPrint(error.localizedDescription)
             return nil
         }
     }
 
-    private nonisolated static func readCircleImages(from imageDatabase: Connection) -> [Int: Data]? {
+    private nonisolated static func readCircleImageIDs(from imageDatabase: Connection) -> Set<Int>? {
+        do {
+            let colID = Expression<Int>("id")
+            let table = Table("ComiketCircleImage").select(colID)
+            return try Set(imageDatabase.prepare(table).map { $0[colID] })
+        } catch {
+            debugPrint(error.localizedDescription)
+            return nil
+        }
+    }
+
+    // Lazy single-row blob reads (indexed primary-key / name lookups), used on demand by the
+    // image accessors in Database+Fetchers when a specific image is actually displayed.
+    static func readCircleImageData(from imageDatabase: Connection, id: Int) -> Data? {
         do {
             let colID = Expression<Int>("id")
             let colCutImage = Expression<Data>("cutImage")
-            let table = Table("ComiketCircleImage").select(colID, colCutImage)
-            return try imageDatabase.prepare(table).reduce(into: [:]) { partialResult, row in
-                partialResult[row[colID]] = row[colCutImage]
-            }
+            let query = Table("ComiketCircleImage").select(colCutImage).filter(colID == id)
+            return try imageDatabase.pluck(query)?[colCutImage]
+        } catch {
+            debugPrint(error.localizedDescription)
+            return nil
+        }
+    }
+
+    static func readCommonImageData(from imageDatabase: Connection, name: String) -> Data? {
+        do {
+            let colName = Expression<String>("name")
+            let colImage = Expression<Data>("image")
+            let query = Table("ComiketCommonImage").select(colImage).filter(colName == name)
+            return try imageDatabase.pluck(query)?[colImage]
         } catch {
             debugPrint(error.localizedDescription)
             return nil

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -81,7 +81,6 @@ public class Database {
             debugPrint("Database: Connecting to image database at \(imageDatabaseURL.path(percentEncoded: false))")
             #endif
             imageDatabase = try? Connection(imageDatabaseURL.path(percentEncoded: false), readonly: true)
-            applyReadOnlyPragmas(to: imageDatabase)
         }
         return imageDatabase
     }
@@ -98,6 +97,17 @@ public class Database {
             PRAGMA query_only = ON;
             """
         )
+    }
+
+    // A fresh, independent read-only connection to the text database. Lets concurrent readers
+    // (e.g. the catalog/search fetch) run in parallel instead of serializing behind heavy work
+    // on the shared connection (e.g. the map's layout query). The connection closes when its
+    // owning DataFetcher is released.
+    public func newReadOnlyTextConnection() -> Connection? {
+        guard let textDatabaseURL else { return nil }
+        let connection = try? Connection(textDatabaseURL.path(percentEncoded: false), readonly: true)
+        applyReadOnlyPragmas(to: connection)
+        return connection
     }
 
     public func disconnect() {

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -266,7 +266,7 @@ public class Database {
 
     // Lazy single-row blob reads (indexed primary-key / name lookups), used on demand by the
     // image accessors in Database+Fetchers when a specific image is actually displayed.
-    static func readCircleImageData(from imageDatabase: Connection, id: Int) -> Data? {
+    nonisolated static func readCircleImageData(from imageDatabase: Connection, id: Int) -> Data? {
         do {
             let colID = Expression<Int>("id")
             let colCutImage = Expression<Data>("cutImage")
@@ -278,7 +278,7 @@ public class Database {
         }
     }
 
-    static func readCommonImageData(from imageDatabase: Connection, name: String) -> Data? {
+    nonisolated static func readCommonImageData(from imageDatabase: Connection, name: String) -> Data? {
         do {
             let colName = Expression<String>("name")
             let colImage = Expression<Data>("image")

--- a/AXiS/Database.swift
+++ b/AXiS/Database.swift
@@ -44,6 +44,7 @@ public class Database {
             debugPrint("Database: Connecting to text database at \(textDatabaseURL.path(percentEncoded: false))")
             #endif
             textDatabase = try? Connection(textDatabaseURL.path(percentEncoded: false), readonly: true)
+            applyReadOnlyPragmas(to: textDatabase)
         }
         return textDatabase
     }
@@ -54,8 +55,23 @@ public class Database {
             debugPrint("Database: Connecting to image database at \(imageDatabaseURL.path(percentEncoded: false))")
             #endif
             imageDatabase = try? Connection(imageDatabaseURL.path(percentEncoded: false), readonly: true)
+            applyReadOnlyPragmas(to: imageDatabase)
         }
         return imageDatabase
+    }
+
+    // Tuning for read-only catalog connections: larger page cache + memory-mapped IO reduce
+    // page-read syscalls (fewer wakeups / less battery) on the large full-table reads and scans.
+    private func applyReadOnlyPragmas(to connection: Connection?) {
+        guard let connection else { return }
+        try? connection.execute(
+            """
+            PRAGMA cache_size = -8000;
+            PRAGMA mmap_size = 268435456;
+            PRAGMA temp_store = MEMORY;
+            PRAGMA query_only = ON;
+            """
+        )
     }
 
     public func disconnect() {

--- a/AXiS/Downloader.swift
+++ b/AXiS/Downloader.swift
@@ -75,6 +75,10 @@ public class Downloader: NSObject, @unchecked Sendable, URLSessionDownloadDelega
         if let error {
             continuation?.resume(throwing: error)
         }
+        // Each download uses a background session with a unique identifier; invalidate it once the
+        // task finishes so we don't leak nsurlsessiond sessions (and the delegate retain) for the
+        // app's lifetime.
+        session.finishTasksAndInvalidate()
     }
     // swiftlint:enable unused_parameter
 }

--- a/AXiS/Downloader.swift
+++ b/AXiS/Downloader.swift
@@ -75,9 +75,6 @@ public class Downloader: NSObject, @unchecked Sendable, URLSessionDownloadDelega
         if let error {
             continuation?.resume(throwing: error)
         }
-        // Each download uses a background session with a unique identifier; invalidate it once the
-        // task finishes so we don't leak nsurlsessiond sessions (and the delegate retain) for the
-        // app's lifetime.
         session.finishTasksAndInvalidate()
     }
     // swiftlint:enable unused_parameter

--- a/App/Actors/DataFetcher.swift
+++ b/App/Actors/DataFetcher.swift
@@ -130,25 +130,56 @@ actor DataFetcher {
     }
 
     func circles(containing searchTerm: String) -> [Int] {
-        if let database {
-            do {
-                let table = Table("ComiketCircleWC")
-                let colID = Expression<Int>("id")
-                let colCircleName = Expression<String>("circleName")
-                let colCircleNameKana = Expression<String>("circleKana")
-                let colPenName = Expression<String>("penName")
-
-                let query = table.select(colID).filter(
-                    colCircleName.like("%\(searchTerm)%") ||
-                    colCircleNameKana.like("%\(searchTerm)%") ||
-                    colPenName.like("%\(searchTerm)%")
-                )
-                return try database.prepare(query).map { $0[colID] }
-            } catch {
-                debugPrint(error.localizedDescription)
-            }
+        guard let database else { return [] }
+        let term = searchTerm.trimmingCharacters(in: .whitespaces)
+        guard !term.isEmpty else { return [] }
+        // FTS5 trigram requires >= 3 characters; use the index when possible, otherwise fall back
+        // to a LIKE scan (also used when the FTS table isn't present on this catalog).
+        if term.count >= 3, let ftsResults = ftsSearch(term, in: database) {
+            return ftsResults
         }
-        return []
+        return likeSearch(term, in: database)
+    }
+
+    private func ftsSearch(_ term: String, in database: Connection) -> [Int]? {
+        let escaped = term.replacingOccurrences(of: "\"", with: "\"\"")
+        let matchQuery = "\"\(escaped)\""
+        do {
+            let statement = try database.prepare(
+                "SELECT rowid FROM CircleSearchFTS WHERE CircleSearchFTS MATCH ? ORDER BY rowid",
+                matchQuery
+            )
+            var ids: [Int] = []
+            for row in statement {
+                if let value = row[0] as? Int64 {
+                    ids.append(Int(value))
+                }
+            }
+            return ids
+        } catch {
+            // FTS table missing/unavailable on this catalog; signal a LIKE fallback.
+            return nil
+        }
+    }
+
+    private func likeSearch(_ term: String, in database: Connection) -> [Int] {
+        do {
+            let table = Table("ComiketCircleWC")
+            let colID = Expression<Int>("id")
+            let colCircleName = Expression<String>("circleName")
+            let colCircleNameKana = Expression<String>("circleKana")
+            let colPenName = Expression<String>("penName")
+
+            let query = table.select(colID).filter(
+                colCircleName.like("%\(term)%") ||
+                colCircleNameKana.like("%\(term)%") ||
+                colPenName.like("%\(term)%")
+            )
+            return try database.prepare(query).map { $0[colID] }
+        } catch {
+            debugPrint(error.localizedDescription)
+            return []
+        }
     }
 
     func circles(

--- a/App/Actors/DataFetcher.swift
+++ b/App/Actors/DataFetcher.swift
@@ -133,8 +133,6 @@ actor DataFetcher {
         guard let database else { return [] }
         let term = searchTerm.trimmingCharacters(in: .whitespaces)
         guard !term.isEmpty else { return [] }
-        // FTS5 trigram requires >= 3 characters; use the index when possible, otherwise fall back
-        // to a LIKE scan (also used when the FTS table isn't present on this catalog).
         if term.count >= 3, let ftsResults = ftsSearch(term, in: database) {
             return ftsResults
         }
@@ -157,7 +155,6 @@ actor DataFetcher {
             }
             return ids
         } catch {
-            // FTS table missing/unavailable on this catalog; signal a LIKE fallback.
             return nil
         }
     }

--- a/App/Actors/FavoritesActor.swift
+++ b/App/Actors/FavoritesActor.swift
@@ -142,7 +142,7 @@ actor FavoritesActor {
         }
 
         if let endpoint = endpointComponents.url {
-            var request = URLRequest(url: endpoint)
+            var request = URLRequest(url: endpoint, timeoutInterval: circleMsAPITimeout)
             request.httpMethod = method
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -153,8 +153,6 @@ class Authenticator {
 
     func setupReachability() {
         guard let reachability else {
-            // No reachability monitor available: bootstrap immediately (best-effort offline) so the
-            // app never waits on a callback that will never arrive.
             bootstrap(isConnected: false)
             return
         }
@@ -165,8 +163,6 @@ class Authenticator {
             Task { self?.handleUnreachable() }
         }
         do {
-            // startNotifier performs the initial flag read, which fires whenReachable/whenUnreachable
-            // and drives the first bootstrap — so launch pays for no synchronous connectivity query.
             try reachability.startNotifier()
         } catch {
             debugPrint(error.localizedDescription)
@@ -174,21 +170,15 @@ class Authenticator {
         }
     }
 
-    // Brings the app to a usable state exactly once, independent of whether any later Reachability
-    // callback arrives. The connectivity result is supplied by the caller (the reachability callback,
-    // or a best-effort default on failure) so the launch path does no synchronous flag read.
     func bootstrap(isConnected: Bool) {
         guard !isReady else { return }
         onlineState = isConnected ? .online : .offline
 
         if restoreAuthenticationFromKeychainAndDefaults() {
-            // Fresh token restored; refresh ahead of expiry only when actually online.
             if isConnected && tokenExpiryDate.addingTimeInterval(-3600) < .now {
                 Task { await refreshAuthenticationToken() }
             }
         } else if !isConnected {
-            // OFFLINE: keep whatever token we have (or an empty placeholder) so already
-            // downloaded data stays browsable; never raise a login wall we can't complete.
             if let storedToken = loadStoredToken(), !storedToken.accessToken.isEmpty {
                 token = storedToken
                 tokenExpiryDate = (UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date) ?? .distantPast
@@ -196,8 +186,6 @@ class Authenticator {
                 useOfflineAuthenticationToken()
             }
         } else {
-            // ONLINE without a fresh token (first run, expired, or revoked): require login so the
-            // user can authenticate before anything that needs the network — notably downloads.
             resetAuthentication()
         }
 
@@ -210,7 +198,6 @@ class Authenticator {
             bootstrap(isConnected: true)
             return
         }
-        // Came online after bootstrap: silently refresh if our token is near/over expiry.
         if let token, !token.accessToken.isEmpty,
            tokenExpiryDate.addingTimeInterval(-3600) < .now {
             await refreshAuthenticationToken()
@@ -240,7 +227,6 @@ class Authenticator {
         return false
     }
 
-    // Loads the stored token regardless of expiry (used for silent refresh / offline browsing).
     func loadStoredToken() -> OpenIDToken? {
         if let tokenInKeychain = try? keychain.get(keychainAuthTokenKey),
            let tokenData = tokenInKeychain.data(using: .utf8),
@@ -253,8 +239,6 @@ class Authenticator {
     func resetAuthentication() {
         code = nil
         token = nil
-        // Remove only the auth token, preserving the cached OpenID client config so the user
-        // can re-login without depending on a fresh CloudKit fetch.
         try? keychain.remove(keychainAuthTokenKey)
         UserDefaults.standard.removeObject(forKey: tokenExpiryDateKey)
         tokenExpiryDate = .distantFuture
@@ -290,19 +274,16 @@ class Authenticator {
             if decodeAuthenticationToken(data: data) {
                 self.isAuthenticating = false
             } else {
-                // Exchange returned a non-token body (bad code / captive portal): stay on login.
                 self.code = nil
                 self.token = nil
                 self.isAuthenticating = true
             }
         } catch {
-            // Network failure during interactive login: keep the login sheet up for retry.
             self.isAuthenticating = true
         }
     }
 
     func useOfflineAuthenticationToken() {
-        // Never overwrite a valid restored token with an empty placeholder.
         if token == nil {
             self.token = OpenIDToken()
         }
@@ -310,7 +291,6 @@ class Authenticator {
 
     func refreshAuthenticationToken() async {
         guard let refreshToken = token?.refreshToken, !refreshToken.isEmpty else {
-            // No refresh token to use; only force interactive login when we are actually online.
             if onlineState == .online {
                 self.isAuthenticating = true
             }
@@ -326,15 +306,11 @@ class Authenticator {
             let (data, response) = try await URLSession.shared.data(for: request)
             if let httpResponse = response as? HTTPURLResponse,
                (400..<500).contains(httpResponse.statusCode) {
-                // Decisive auth rejection (e.g. revoked / invalid_grant): require fresh login.
                 resetAuthentication()
                 return
             }
-            // On success, the token is updated. On a non-decodable 2xx (captive portal HTML, etc.)
-            // we deliberately keep the existing token so local data stays usable offline.
             _ = decodeAuthenticationToken(data: data)
         } catch {
-            // Transient network failure: keep the existing token; do not force a login wall.
         }
     }
 
@@ -345,7 +321,6 @@ class Authenticator {
                 tokenExpiryDate = storedExpiry
             }
         }
-        // Skip the network round-trip entirely when the token is still fresh (battery).
         if tokenExpiryDate.addingTimeInterval(-3600) > .now {
             return
         }

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -151,16 +151,34 @@ class Authenticator {
         return nil
     }
 
-    // Bring the app to a usable state without waiting for any Reachability callback.
-    // The on-disk catalog must always load, even when Reachability cannot be created or
-    // its notifier never fires. Connectivity is resolved synchronously here (best-effort);
-    // live changes are handled afterwards by the notifier.
-    func bootstrap() {
-        guard !isReady else { return }
+    func setupReachability() {
+        guard let reachability else {
+            // No reachability monitor available: bootstrap immediately (best-effort offline) so the
+            // app never waits on a callback that will never arrive.
+            bootstrap(isConnected: false)
+            return
+        }
+        reachability.whenReachable = { [weak self] _ in
+            Task { await self?.handleReachable() }
+        }
+        reachability.whenUnreachable = { [weak self] _ in
+            Task { self?.handleUnreachable() }
+        }
+        do {
+            // startNotifier performs the initial flag read, which fires whenReachable/whenUnreachable
+            // and drives the first bootstrap — so launch pays for no synchronous connectivity query.
+            try reachability.startNotifier()
+        } catch {
+            debugPrint(error.localizedDescription)
+            bootstrap(isConnected: false)
+        }
+    }
 
-        // Best-effort synchronous connectivity read; default to offline when unknown so the
-        // app never hangs and always falls back to already-downloaded data.
-        let isConnected = (reachability?.connection ?? .unavailable) != .unavailable
+    // Brings the app to a usable state exactly once, independent of whether any later Reachability
+    // callback arrives. The connectivity result is supplied by the caller (the reachability callback,
+    // or a best-effort default on failure) so the launch path does no synchronous flag read.
+    func bootstrap(isConnected: Bool) {
+        guard !isReady else { return }
         onlineState = isConnected ? .online : .offline
 
         if restoreAuthenticationFromKeychainAndDefaults() {
@@ -170,8 +188,7 @@ class Authenticator {
             }
         } else if !isConnected {
             // OFFLINE: keep whatever token we have (or an empty placeholder) so already
-            // downloaded data stays browsable; never raise a login wall we can't complete
-            // without a network.
+            // downloaded data stays browsable; never raise a login wall we can't complete.
             if let storedToken = loadStoredToken(), !storedToken.accessToken.isEmpty {
                 token = storedToken
                 tokenExpiryDate = (UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date) ?? .distantPast
@@ -181,37 +198,16 @@ class Authenticator {
         } else {
             // ONLINE without a fresh token (first run, expired, or revoked): require login so the
             // user can authenticate before anything that needs the network — notably downloads.
-            // Keeping a stale token here would silently break the size probe and the download.
             resetAuthentication()
         }
 
         isReady = true
     }
 
-    func setupReachability() {
-        if let reachability {
-            reachability.whenReachable = { [weak self] _ in
-                Task {
-                    await self?.handleReachable()
-                }
-            }
-            reachability.whenUnreachable = { [weak self] _ in
-                Task {
-                    self?.handleUnreachable()
-                }
-            }
-            do {
-                try reachability.startNotifier()
-            } catch {
-                debugPrint(error.localizedDescription)
-            }
-        }
-    }
-
     private func handleReachable() async {
         onlineState = .online
         if !isReady {
-            bootstrap()
+            bootstrap(isConnected: true)
             return
         }
         // Came online after bootstrap: silently refresh if our token is near/over expiry.
@@ -224,7 +220,7 @@ class Authenticator {
     private func handleUnreachable() {
         onlineState = .offline
         if !isReady {
-            bootstrap()
+            bootstrap(isConnected: false)
             return
         }
         useOfflineAuthenticationToken()

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -168,23 +168,21 @@ class Authenticator {
             if isConnected && tokenExpiryDate.addingTimeInterval(-3600) < .now {
                 Task { await refreshAuthenticationToken() }
             }
-        } else if let storedToken = loadStoredToken(), !storedToken.refreshToken.isEmpty {
-            // We have a (possibly expired) token with a refresh token. Keep it so on-disk data
-            // stays browsable; attempt a silent refresh when online instead of forcing login.
-            token = storedToken
-            if let storedExpiry = UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date {
-                tokenExpiryDate = storedExpiry
-            }
-            if isConnected {
-                Task { await refreshAuthenticationToken() }
-            }
-        } else {
-            // No usable credentials.
-            if isConnected {
-                resetAuthentication()
+        } else if !isConnected {
+            // OFFLINE: keep whatever token we have (or an empty placeholder) so already
+            // downloaded data stays browsable; never raise a login wall we can't complete
+            // without a network.
+            if let storedToken = loadStoredToken(), !storedToken.accessToken.isEmpty {
+                token = storedToken
+                tokenExpiryDate = (UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date) ?? .distantPast
             } else {
                 useOfflineAuthenticationToken()
             }
+        } else {
+            // ONLINE without a fresh token (first run, expired, or revoked): require login so the
+            // user can authenticate before anything that needs the network — notably downloads.
+            // Keeping a stale token here would silently break the size probe and the download.
+            resetAuthentication()
         }
 
         isReady = true

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -164,6 +164,14 @@ class Authenticator {
         }
         do {
             try reachability.startNotifier()
+            // The notifier normally fires an initial callback that calls bootstrap,
+            // but if it never does the app would hang on the loading screen forever.
+            // Fall back to a connectivity-agnostic bootstrap after a short grace period.
+            Task { [weak self] in
+                try? await Task.sleep(for: .seconds(3))
+                guard let self, !self.isReady else { return }
+                self.bootstrap(isConnected: self.onlineState == .online)
+            }
         } catch {
             debugPrint(error.localizedDescription)
             bootstrap(isConnected: false)

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -151,6 +151,45 @@ class Authenticator {
         return nil
     }
 
+    // Bring the app to a usable state without waiting for any Reachability callback.
+    // The on-disk catalog must always load, even when Reachability cannot be created or
+    // its notifier never fires. Connectivity is resolved synchronously here (best-effort);
+    // live changes are handled afterwards by the notifier.
+    func bootstrap() {
+        guard !isReady else { return }
+
+        // Best-effort synchronous connectivity read; default to offline when unknown so the
+        // app never hangs and always falls back to already-downloaded data.
+        let isConnected = (reachability?.connection ?? .unavailable) != .unavailable
+        onlineState = isConnected ? .online : .offline
+
+        if restoreAuthenticationFromKeychainAndDefaults() {
+            // Fresh token restored; refresh ahead of expiry only when actually online.
+            if isConnected && tokenExpiryDate.addingTimeInterval(-3600) < .now {
+                Task { await refreshAuthenticationToken() }
+            }
+        } else if let storedToken = loadStoredToken(), !storedToken.refreshToken.isEmpty {
+            // We have a (possibly expired) token with a refresh token. Keep it so on-disk data
+            // stays browsable; attempt a silent refresh when online instead of forcing login.
+            token = storedToken
+            if let storedExpiry = UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date {
+                tokenExpiryDate = storedExpiry
+            }
+            if isConnected {
+                Task { await refreshAuthenticationToken() }
+            }
+        } else {
+            // No usable credentials.
+            if isConnected {
+                resetAuthentication()
+            } else {
+                useOfflineAuthenticationToken()
+            }
+        }
+
+        isReady = true
+    }
+
     func setupReachability() {
         if let reachability {
             reachability.whenReachable = { [weak self] _ in
@@ -172,30 +211,25 @@ class Authenticator {
     }
 
     private func handleReachable() async {
-        self.onlineState = .online
-        if !self.isReady {
-            // Restore previous authentication token
-            if !self.restoreAuthenticationFromKeychainAndDefaults() {
-                self.resetAuthentication()
-                self.isReady = true
-            } else {
-                // Refresh authentication token in the background if close to expiry
-                if self.tokenExpiryDate.addingTimeInterval(-3600) < .now {
-                    Task {
-                        await self.refreshAuthenticationToken()
-                    }
-                }
-                self.isReady = true
-            }
+        onlineState = .online
+        if !isReady {
+            bootstrap()
+            return
+        }
+        // Came online after bootstrap: silently refresh if our token is near/over expiry.
+        if let token, !token.accessToken.isEmpty,
+           tokenExpiryDate.addingTimeInterval(-3600) < .now {
+            await refreshAuthenticationToken()
         }
     }
 
     private func handleUnreachable() {
-        self.onlineState = .offline
-        self.useOfflineAuthenticationToken()
-        if !self.isReady {
-            self.isReady = true
+        onlineState = .offline
+        if !isReady {
+            bootstrap()
+            return
         }
+        useOfflineAuthenticationToken()
     }
 
     func restoreAuthenticationFromKeychainAndDefaults() -> Bool {
@@ -212,11 +246,24 @@ class Authenticator {
         return false
     }
 
+    // Loads the stored token regardless of expiry (used for silent refresh / offline browsing).
+    func loadStoredToken() -> OpenIDToken? {
+        if let tokenInKeychain = try? keychain.get(keychainAuthTokenKey),
+           let tokenData = tokenInKeychain.data(using: .utf8),
+           let token = try? JSONDecoder().decode(OpenIDToken.self, from: tokenData) {
+            return token
+        }
+        return nil
+    }
+
     func resetAuthentication() {
         code = nil
         token = nil
-        try? keychain.removeAll()
-        UserDefaults.standard.removeObject(forKey: keychainAuthTokenKey)
+        // Remove only the auth token, preserving the cached OpenID client config so the user
+        // can re-login without depending on a fresh CloudKit fetch.
+        try? keychain.remove(keychainAuthTokenKey)
+        UserDefaults.standard.removeObject(forKey: tokenExpiryDateKey)
+        tokenExpiryDate = .distantFuture
         isAuthenticating = true
     }
 
@@ -244,67 +291,96 @@ class Authenticator {
             "code": code ?? ""
         ])
 
-        if let (data, _) = try? await URLSession.shared.data(for: request) {
-            let isSuccessful = decodeAuthenticationToken(data: data)
-            if isSuccessful {
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            if decodeAuthenticationToken(data: data) {
                 self.isAuthenticating = false
+            } else {
+                // Exchange returned a non-token body (bad code / captive portal): stay on login.
+                self.code = nil
+                self.token = nil
+                self.isAuthenticating = true
             }
-        } else {
-            self.token = nil
+        } catch {
+            // Network failure during interactive login: keep the login sheet up for retry.
             self.isAuthenticating = true
         }
     }
 
     func useOfflineAuthenticationToken() {
-        self.token = OpenIDToken()
+        // Never overwrite a valid restored token with an empty placeholder.
+        if token == nil {
+            self.token = OpenIDToken()
+        }
     }
 
     func refreshAuthenticationToken() async {
-        if let refreshToken = token?.refreshToken {
-            let request = urlRequestForToken(parameters: [
-                "grant_type": "refresh_token",
-                "refresh_token": refreshToken
-            ])
-
-            if let (data, _) = try? await URLSession.shared.data(for: request) {
-                _ = decodeAuthenticationToken(data: data)
-            } else {
+        guard let refreshToken = token?.refreshToken, !refreshToken.isEmpty else {
+            // No refresh token to use; only force interactive login when we are actually online.
+            if onlineState == .online {
                 self.isAuthenticating = true
             }
-        } else {
-            self.isAuthenticating = true
+            return
+        }
+
+        let request = urlRequestForToken(parameters: [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken
+        ])
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse,
+               (400..<500).contains(httpResponse.statusCode) {
+                // Decisive auth rejection (e.g. revoked / invalid_grant): require fresh login.
+                resetAuthentication()
+                return
+            }
+            // On success, the token is updated. On a non-decodable 2xx (captive portal HTML, etc.)
+            // we deliberately keep the existing token so local data stays usable offline.
+            _ = decodeAuthenticationToken(data: data)
+        } catch {
+            // Transient network failure: keep the existing token; do not force a login wall.
         }
     }
 
     func refreshAuthenticationTokenInBackground() async {
         if token == nil {
-            _ = restoreAuthenticationFromKeychainAndDefaults()
+            token = loadStoredToken()
+            if let storedExpiry = UserDefaults.standard.object(forKey: tokenExpiryDateKey) as? Date {
+                tokenExpiryDate = storedExpiry
+            }
         }
-        guard let refreshToken = token?.refreshToken else { return }
+        // Skip the network round-trip entirely when the token is still fresh (battery).
+        if tokenExpiryDate.addingTimeInterval(-3600) > .now {
+            return
+        }
+        guard let refreshToken = token?.refreshToken, !refreshToken.isEmpty else { return }
         let request = urlRequestForToken(parameters: [
             "grant_type": "refresh_token",
             "refresh_token": refreshToken
         ], timeoutInterval: 10.0)
-        if let (data, _) = try? await URLSession.shared.data(for: request) {
+        if let (data, response) = try? await URLSession.shared.data(for: request) {
+            if let httpResponse = response as? HTTPURLResponse,
+               (400..<500).contains(httpResponse.statusCode) {
+                return
+            }
             _ = decodeAuthenticationToken(data: data)
         }
     }
 
+    @discardableResult
     func decodeAuthenticationToken(data: Data) -> Bool {
-        if let token = try? JSONDecoder().decode(OpenIDToken.self, from: data) {
-            self.token = token
-            self.updateTokenExpiryDate(from: token)
-            if let tokenEncoded = try? JSONEncoder().encode(token),
-               let tokenString = String(data: tokenEncoded, encoding: .utf8) {
-                try? keychain.set(tokenString, key: keychainAuthTokenKey)
-            }
-            return true
-        } else {
-            self.code = nil
-            self.token = nil
-            self.isAuthenticating = true
+        guard let token = try? JSONDecoder().decode(OpenIDToken.self, from: data) else {
             return false
         }
+        self.token = token
+        self.updateTokenExpiryDate(from: token)
+        if let tokenEncoded = try? JSONEncoder().encode(token),
+           let tokenString = String(data: tokenEncoded, encoding: .utf8) {
+            try? keychain.set(tokenString, key: keychainAuthTokenKey)
+        }
+        return true
     }
 
     func updateTokenExpiryDate(from token: OpenIDToken) {
@@ -314,7 +390,7 @@ class Authenticator {
         self.tokenExpiryDate = tokenExpiryDate
     }
 
-    func urlRequestForToken(parameters: [String: String], timeoutInterval: TimeInterval = 2.0) -> URLRequest {
+    func urlRequestForToken(parameters: [String: String], timeoutInterval: TimeInterval = circleMsTokenTimeout) -> URLRequest {
         let endpoint = URL(string: "\(circleMsAuthEndpoint)/OAuth2/Token")!
 
         var parameters: [String: String] = parameters

--- a/App/Classes/Authenticator.swift
+++ b/App/Classes/Authenticator.swift
@@ -319,6 +319,9 @@ class Authenticator {
             }
             _ = decodeAuthenticationToken(data: data)
         } catch {
+            // Transient failure (timeout, offline, captive portal): keep the existing
+            // token and retry later rather than forcing re-login. Only a decisive 4xx
+            // (handled above) clears authentication.
         }
     }
 

--- a/App/Classes/CatalogCache.swift
+++ b/App/Classes/CatalogCache.swift
@@ -21,7 +21,7 @@ class CatalogCache {
     static func fetchCircles(
         genreIDs: [Int]?, mapID: Int?, blockIDs: [Int]?, dayID: Int?, database: Database
     ) async -> [Int] {
-        let actor = DataFetcher(database: await database.getTextDatabase())
+        let actor = DataFetcher(database: await database.newReadOnlyTextConnection())
         return await actor.circles(
             inMap: mapID,
             withGenre: genreIDs,
@@ -31,7 +31,7 @@ class CatalogCache {
     }
 
     static func fetchGenreIDs(inMap mapID: Int, onDay dayID: Int, database: Database) async -> [Int] {
-        let actor = DataFetcher(database: await database.getTextDatabase())
+        let actor = DataFetcher(database: await database.newReadOnlyTextConnection())
         return await actor.genreIDs(inMap: mapID, onDay: dayID)
     }
 
@@ -41,12 +41,12 @@ class CatalogCache {
         withGenreIDs genreIDs: [Int]?,
         database: Database
     ) async -> [Int] {
-        let actor = DataFetcher(database: await database.getTextDatabase())
+        let actor = DataFetcher(database: await database.newReadOnlyTextConnection())
         return await actor.blockIDs(inMap: mapID, onDay: dayID, withGenreIDs: genreIDs)
     }
 
     static func searchCircles(_ searchTerm: String, database: Database) async -> [Int]? {
-        let actor = DataFetcher(database: await database.getTextDatabase())
+        let actor = DataFetcher(database: await database.newReadOnlyTextConnection())
         if searchTerm.trimmingCharacters(in: .whitespaces).count >= 2 {
             let circleIdentifiers = await actor.circles(containing: searchTerm)
             return circleIdentifiers

--- a/App/Classes/Events.swift
+++ b/App/Classes/Events.swift
@@ -157,8 +157,6 @@ class Events {
                 )
             }
         case .offline, .undetermined:
-            // Even when connectivity is unknown, fall back to the on-disk event so already
-            // downloaded data can load instead of dead-ending on a blank screen.
             activeEvent = WebCatalogEvent.Response.Event(
                 id: activeEventNumber,
                 number: activeEventNumber

--- a/App/Classes/Events.swift
+++ b/App/Classes/Events.swift
@@ -156,12 +156,13 @@ class Events {
                     number: activeEventNumber
                 )
             }
-        case .offline:
+        case .offline, .undetermined:
+            // Even when connectivity is unknown, fall back to the on-disk event so already
+            // downloaded data can load instead of dead-ending on a blank screen.
             activeEvent = WebCatalogEvent.Response.Event(
                 id: activeEventNumber,
                 number: activeEventNumber
             )
-        case .undetermined: break
         }
     }
 

--- a/App/Classes/ImageCache.swift
+++ b/App/Classes/ImageCache.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import RADiUS
 import SwiftUI
 import UIKit
 import WebP
@@ -72,7 +73,8 @@ class ImageCache {
 
     static func download(id: Int, url: URL) async -> (UIImage?, Data?) {
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let request = URLRequest(url: url, timeoutInterval: circleMsAPITimeout)
+            let (data, _) = try await URLSession.shared.data(for: request)
             var finalImage: UIImage?
             var finalData: Data?
             if let image = UIImage(data: data) {

--- a/App/View Modifiers/DataLifecycle.swift
+++ b/App/View Modifiers/DataLifecycle.swift
@@ -235,6 +235,7 @@ struct DataLifecycleModifier: ViewModifier {
             if oasis.isShowing {
                 await oasis.setBodyText("Loading.Database")
             }
+            await database.prepareIndexes(for: activeEvent)
             selections.reloadData(database: database)
 
             if oasis.isShowing {

--- a/App/View Modifiers/DataLifecycle.swift
+++ b/App/View Modifiers/DataLifecycle.swift
@@ -247,7 +247,7 @@ struct DataLifecycleModifier: ViewModifier {
                 isDatabaseInitialized = true
             }
 
-            database.imageCache.removeAll()
+            database.clearDecodedImages()
         }
 
         UIApplication.shared.isIdleTimerDisabled = false

--- a/App/View Modifiers/ReachabilitySetup.swift
+++ b/App/View Modifiers/ReachabilitySetup.swift
@@ -14,9 +14,8 @@ struct ReachabilitySetupModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .task {
-                // Make the app usable from on-disk data immediately, independent of connectivity,
-                // then start observing live network changes.
-                authenticator.bootstrap()
+                // Starting the notifier performs the single connectivity read and drives the
+                // initial bootstrap from its callback — no extra synchronous work on the launch path.
                 authenticator.setupReachability()
             }
     }

--- a/App/View Modifiers/ReachabilitySetup.swift
+++ b/App/View Modifiers/ReachabilitySetup.swift
@@ -14,8 +14,6 @@ struct ReachabilitySetupModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .task {
-                // Starting the notifier performs the single connectivity read and drives the
-                // initial bootstrap from its callback — no extra synchronous work on the launch path.
                 authenticator.setupReachability()
             }
     }

--- a/App/View Modifiers/ReachabilitySetup.swift
+++ b/App/View Modifiers/ReachabilitySetup.swift
@@ -14,6 +14,9 @@ struct ReachabilitySetupModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .task {
+                // Make the app usable from on-disk data immediately, independent of connectivity,
+                // then start observing live network changes.
+                authenticator.bootstrap()
                 authenticator.setupReachability()
             }
     }

--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -99,10 +99,6 @@ struct CirclesApp: App {
                 switch newValue {
                 case .active:
                     if authenticator.token != nil && authenticator.onlineState == .online {
-                        // Silently refresh at/within an hour of expiry. refreshAuthenticationToken()
-                        // only escalates to interactive login on a decisive auth rejection, so an
-                        // expired token on a slow/broken network no longer walls the user off from
-                        // already-downloaded data.
                         if authenticator.tokenExpiryDate.addingTimeInterval(-3600) < .now {
                             Task {
                                 await authenticator.refreshAuthenticationToken()

--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -99,17 +99,15 @@ struct CirclesApp: App {
                 switch newValue {
                 case .active:
                     if authenticator.token != nil && authenticator.onlineState == .online {
-                        // Require authentication when token expires
-                        if authenticator.tokenExpiryDate < .now {
-                            unifier.hide()
-                            authenticator.isAuthenticating = true
-                        // Refresh authentication token 1 hour before expiry
-                        } else if authenticator.tokenExpiryDate.addingTimeInterval(-3600) < .now {
+                        // Silently refresh at/within an hour of expiry. refreshAuthenticationToken()
+                        // only escalates to interactive login on a decisive auth rejection, so an
+                        // expired token on a slow/broken network no longer walls the user off from
+                        // already-downloaded data.
+                        if authenticator.tokenExpiryDate.addingTimeInterval(-3600) < .now {
                             Task {
                                 await authenticator.refreshAuthenticationToken()
                             }
                         }
-                        // Do nothing in any other case
                     }
                 case .background:
                     registerBackgroundRefreshTask()

--- a/App/Views/Catalog/CatalogView.swift
+++ b/App/Views/Catalog/CatalogView.swift
@@ -144,8 +144,12 @@ struct CatalogView: View {
         .onChange(of: selections.catalogSelectionID) {
             reloadDisplayedCircles()
         }
-        .onChange(of: searchTerm) {
-            searchCircles()
+        .task(id: searchTerm) {
+            // Debounce: SwiftUI cancels the prior task when searchTerm changes, so only the
+            // final keystroke runs the full-table scan instead of one scan per character.
+            try? await Task.sleep(for: .milliseconds(250))
+            if Task.isCancelled { return }
+            await searchCircles()
         }
         .onChange(of: isSearchActive) {
             if isSearchActive && unifier.isMinimized {
@@ -190,14 +194,14 @@ struct CatalogView: View {
                 )
 
                 await MainActor.run {
-                    let displayedCircles = database.circles(circleIdentifiers)
+                    // Assign the (potentially large) array without animation; reserve the
+                    // animation for the loading-spinner crossfade only.
+                    catalogCache.displayedCircles = database.circles(circleIdentifiers)
                     if animated {
                         withAnimation(.smooth.speed(2.0)) {
-                            catalogCache.displayedCircles = displayedCircles
                             catalogCache.isLoading = false
                         }
                     } else {
-                        catalogCache.displayedCircles = displayedCircles
                         catalogCache.isLoading = false
                     }
                 }
@@ -225,25 +229,14 @@ struct CatalogView: View {
         }
     }
 
-    func searchCircles() {
-        Task.detached {
-            let circleIdentifiers = await CatalogCache.searchCircles(searchTerm, database: database)
-
-            if let circleIdentifiers {
-                await MainActor.run {
-                    let searchedCircles = database.circles(circleIdentifiers)
-                    withAnimation(.smooth.speed(2.0)) {
-                        catalogCache.searchedCircles = searchedCircles
-                    }
-                }
-            } else {
-                await MainActor.run {
-                    withAnimation(.smooth.speed(2.0)) {
-                        catalogCache.searchedCircles = nil
-                    }
-                }
-            }
+    func searchCircles() async {
+        let circleIdentifiers = await CatalogCache.searchCircles(searchTerm, database: database)
+        if Task.isCancelled { return }
+        // Assign results without animating the whole collection (avoids a full diff/animate per query).
+        if let circleIdentifiers {
+            catalogCache.searchedCircles = database.circles(circleIdentifiers)
+        } else {
+            catalogCache.searchedCircles = nil
         }
-
     }
 }

--- a/App/Views/Catalog/CatalogView.swift
+++ b/App/Views/Catalog/CatalogView.swift
@@ -145,8 +145,6 @@ struct CatalogView: View {
             reloadDisplayedCircles()
         }
         .task(id: searchTerm) {
-            // Debounce: SwiftUI cancels the prior task when searchTerm changes, so only the
-            // final keystroke runs the full-table scan instead of one scan per character.
             try? await Task.sleep(for: .milliseconds(250))
             if Task.isCancelled { return }
             await searchCircles()
@@ -194,8 +192,6 @@ struct CatalogView: View {
                 )
 
                 await MainActor.run {
-                    // Assign the (potentially large) array without animation; reserve the
-                    // animation for the loading-spinner crossfade only.
                     catalogCache.displayedCircles = database.circles(circleIdentifiers)
                     if animated {
                         withAnimation(.smooth.speed(2.0)) {
@@ -232,7 +228,6 @@ struct CatalogView: View {
     func searchCircles() async {
         let circleIdentifiers = await CatalogCache.searchCircles(searchTerm, database: database)
         if Task.isCancelled { return }
-        // Assign results without animating the whole collection (avoids a full diff/animate per query).
         if let circleIdentifiers {
             catalogCache.searchedCircles = database.circles(circleIdentifiers)
         } else {

--- a/App/Views/Map/MapView+Functions.swift
+++ b/App/Views/Map/MapView+Functions.swift
@@ -21,19 +21,20 @@ extension MapView {
             mapper.removeAllLayouts()
             mapImage = nil
             genreImage = nil
-        } completion: {
-            Task { await reloadMapImage() }
-            if let map = selections.map {
-                let mapID = map.id
-                let selectedDate = selections.date?.id
-                let useHighResolutionMaps = useHighResolutionMaps
-                Task.detached {
-                    await reloadMapLayouts(
-                        mapID: mapID,
-                        selectedDate: selectedDate,
-                        useHighResolutionMaps: useHighResolutionMaps
-                    )
-                }
+        }
+        // Kick off the image and layout loads immediately rather than waiting for the
+        // clear animation to finish, so the map and its overlays appear as soon as possible.
+        Task { await reloadMapImage() }
+        if let map = selections.map {
+            let mapID = map.id
+            let selectedDate = selections.date?.id
+            let useHighResolutionMaps = useHighResolutionMaps
+            Task.detached {
+                await reloadMapLayouts(
+                    mapID: mapID,
+                    selectedDate: selectedDate,
+                    useHighResolutionMaps: useHighResolutionMaps
+                )
             }
         }
     }
@@ -46,18 +47,33 @@ extension MapView {
             genreImage = nil
             return
         }
+        // Show the base map (and everything layered on it, including the filter dim) as
+        // soon as it decodes — don't block it behind the optional genre overlay.
         let newMapImage = await database.mapImageAsync(
-            for: selectedHall,
-            on: date.id,
-            usingHighDefinition: useHighResolutionMaps
-        )
-        let newGenreImage = await database.genreImageAsync(
             for: selectedHall,
             on: date.id,
             usingHighDefinition: useHighResolutionMaps
         )
         withAnimation(.smooth.speed(2.0)) {
             mapImage = newMapImage
+        }
+        await reloadGenreImage()
+    }
+
+    func reloadGenreImage() async {
+        guard showGenreOverlay,
+              let date = selections.date,
+              let map = selections.map,
+              let selectedHall = ComiketHall(rawValue: map.filename) else {
+            genreImage = nil
+            return
+        }
+        let newGenreImage = await database.genreImageAsync(
+            for: selectedHall,
+            on: date.id,
+            usingHighDefinition: useHighResolutionMaps
+        )
+        withAnimation(.smooth.speed(2.0)) {
             genreImage = newGenreImage
         }
     }

--- a/App/Views/Map/MapView+Functions.swift
+++ b/App/Views/Map/MapView+Functions.swift
@@ -19,8 +19,10 @@ extension MapView {
     func reloadAll() {
         withAnimation(.smooth.speed(2.0)) {
             mapper.removeAllLayouts()
-            reloadMapImage()
+            mapImage = nil
+            genreImage = nil
         } completion: {
+            Task { await reloadMapImage() }
             if let map = selections.map {
                 let mapID = map.id
                 let selectedDate = selections.date?.id
@@ -36,23 +38,27 @@ extension MapView {
         }
     }
 
-    func reloadMapImage() {
-        if let date = selections.date,
-           let map = selections.map,
-           let selectedHall = ComiketHall(rawValue: map.filename) {
-            mapImage = database.mapImage(
-                for: selectedHall,
-                on: date.id,
-                usingHighDefinition: useHighResolutionMaps
-            )
-            genreImage = database.genreImage(
-                for: selectedHall,
-                on: date.id,
-                usingHighDefinition: useHighResolutionMaps
-            )
-        } else {
+    func reloadMapImage() async {
+        guard let date = selections.date,
+              let map = selections.map,
+              let selectedHall = ComiketHall(rawValue: map.filename) else {
             mapImage = nil
             genreImage = nil
+            return
+        }
+        let newMapImage = await database.mapImageAsync(
+            for: selectedHall,
+            on: date.id,
+            usingHighDefinition: useHighResolutionMaps
+        )
+        let newGenreImage = await database.genreImageAsync(
+            for: selectedHall,
+            on: date.id,
+            usingHighDefinition: useHighResolutionMaps
+        )
+        withAnimation(.smooth.speed(2.0)) {
+            mapImage = newMapImage
+            genreImage = newGenreImage
         }
     }
 

--- a/App/Views/Map/MapView+Functions.swift
+++ b/App/Views/Map/MapView+Functions.swift
@@ -59,8 +59,6 @@ extension MapView {
     func reloadMapLayouts(mapID: Int, selectedDate: Int?, useHighResolutionMaps: Bool) async {
         var layoutWebCatalogIDMappings: [LayoutCatalogMapping: [Int]] = [:]
         if let selectedDate {
-            // Fetch map layouts on a dedicated connection so this heavy query doesn't serialize
-            // behind (or block) the catalog hydration on the shared connection.
             let actor = DataFetcher(database: database.newReadOnlyTextConnection())
             let layoutCatalogMappings = await actor.layoutMappings(
                 inMap: mapID,

--- a/App/Views/Map/MapView+Functions.swift
+++ b/App/Views/Map/MapView+Functions.swift
@@ -59,8 +59,9 @@ extension MapView {
     func reloadMapLayouts(mapID: Int, selectedDate: Int?, useHighResolutionMaps: Bool) async {
         var layoutWebCatalogIDMappings: [LayoutCatalogMapping: [Int]] = [:]
         if let selectedDate {
-            // Fetch map layouts
-            let actor = DataFetcher(database: database.getTextDatabase())
+            // Fetch map layouts on a dedicated connection so this heavy query doesn't serialize
+            // behind (or block) the catalog hydration on the shared connection.
+            let actor = DataFetcher(database: database.newReadOnlyTextConnection())
             let layoutCatalogMappings = await actor.layoutMappings(
                 inMap: mapID,
                 useHighResolutionMaps: useHighResolutionMaps

--- a/App/Views/Map/MapView.swift
+++ b/App/Views/Map/MapView.swift
@@ -33,7 +33,9 @@ struct MapView: View {
     }
 
     var mapInvalidationID: String {
-        "M\(selections.fullMapID)_R\(useHighResolutionMaps ? "H" : "L")_D\(database.commonImagesLoadCount)"
+        // Note: not keyed on commonImagesLoadCount — common images now load lazily on demand, so
+        // the map no longer needs to rebuild (and re-run the heavy layout query) when they finish.
+        "M\(selections.fullMapID)_R\(useHighResolutionMaps ? "H" : "L")"
     }
 
     var popoverInvalidationID: String {

--- a/App/Views/Map/MapView.swift
+++ b/App/Views/Map/MapView.swift
@@ -98,6 +98,9 @@ struct MapView: View {
                 updateCanvasSize(mapImage)
             }
         }
+        .onChange(of: showGenreOverlay) {
+            Task { await reloadGenreImage() }
+        }
         .onChange(of: mapper.highlightTarget) { oldValue, newValue in
             if oldValue == nil && newValue != nil {
                 Task {

--- a/App/Views/Map/MapView.swift
+++ b/App/Views/Map/MapView.swift
@@ -33,8 +33,6 @@ struct MapView: View {
     }
 
     var mapInvalidationID: String {
-        // Note: not keyed on commonImagesLoadCount — common images now load lazily on demand, so
-        // the map no longer needs to rebuild (and re-run the heavy layout query) when they finish.
         "M\(selections.fullMapID)_R\(useHighResolutionMaps ? "H" : "L")"
     }
 

--- a/App/Views/Shared/CircleCutImage.swift
+++ b/App/Views/Shared/CircleCutImage.swift
@@ -161,11 +161,7 @@ struct CircleCutImage: View {
         }
     }
 
-    // Loads the catalog cut off the main thread. `force` overwrites an existing image (used when
-    // switching back to the catalog cut); otherwise it only fills an empty slot so it never clobbers
-    // a freshly fetched web cut.
     func loadCatalogCut(force: Bool = false) {
-        // Fast path: an already-decoded cut is returned synchronously from the in-memory cache.
         if let cached = database.cachedCircleImage(for: circle.id) {
             cutImage = cached
             return

--- a/App/Views/Shared/CircleCutImage.swift
+++ b/App/Views/Shared/CircleCutImage.swift
@@ -144,7 +144,7 @@ struct CircleCutImage: View {
         }
         .onChange(of: database.circleImagesLoadCount) {
             if cutImage == nil {
-                cutImage = database.circleImage(for: circle.id)
+                loadCatalogCut()
             }
         }
         .onChange(of: circle.id) {
@@ -154,9 +154,27 @@ struct CircleCutImage: View {
         .onChange(of: cutType) { _, newValue in
             switch newValue {
             case .catalog:
-                cutImage = database.circleImage(for: circle.id)
+                loadCatalogCut(force: true)
             case .web:
                 prepareCutImage()
+            }
+        }
+    }
+
+    // Loads the catalog cut off the main thread. `force` overwrites an existing image (used when
+    // switching back to the catalog cut); otherwise it only fills an empty slot so it never clobbers
+    // a freshly fetched web cut.
+    func loadCatalogCut(force: Bool = false) {
+        // Fast path: an already-decoded cut is returned synchronously from the in-memory cache.
+        if let cached = database.cachedCircleImage(for: circle.id) {
+            cutImage = cached
+            return
+        }
+        let circleID = circle.id
+        Task {
+            let image = await database.circleImageAsync(for: circleID)
+            if circle.id == circleID, force || cutImage == nil {
+                cutImage = image
             }
         }
     }
@@ -164,7 +182,7 @@ struct CircleCutImage: View {
     func prepareCutImage() {
         // Set the catalog cut as the default
         if cutImage == nil {
-            cutImage = database.circleImage(for: circle.id)
+            loadCatalogCut()
         }
         // Only fetch web cut when cutType is .web and we're online
         if cutType == .web && authenticator.onlineState == .online,

--- a/App/Views/Shared/CircleCutImage.swift
+++ b/App/Views/Shared/CircleCutImage.swift
@@ -71,7 +71,7 @@ struct CircleCutImage: View {
         }
         .aspectRatio(180.0 / 256.0, contentMode: .fit)
         .overlay {
-            if database.circleImage(for: circle.id) != nil {
+            if database.hasCircleImage(circle.id) {
                 Canvas { context, size in
                     // Favorite color
                     if let favorites = favorites.wcIDMappedItems,

--- a/App/Views/Unified/UnifiedView.swift
+++ b/App/Views/Unified/UnifiedView.swift
@@ -140,8 +140,6 @@ struct UnifiedView: View {
         launchCount += 1
         guard launchCount > 2, !hasReviewBeenPrompted else { return }
         Task {
-            // Don't interrupt startup-to-find: wait until the app has settled, and only prompt
-            // once data is loaded and nothing else is in the way.
             try? await Task.sleep(for: .seconds(8))
             guard authenticator.isReady, !authenticator.isAuthenticating, !oasis.isShowing else { return }
             requestReview()

--- a/App/Views/Unified/UnifiedView.swift
+++ b/App/Views/Unified/UnifiedView.swift
@@ -12,6 +12,7 @@ struct UnifiedView: View {
     @Environment(Events.self) var planner
     @Environment(Unifier.self) var unifier
     @Environment(Orientation.self) var orientation
+    @Environment(Oasis.self) var oasis
 
     @Namespace var namespace
 
@@ -137,7 +138,12 @@ struct UnifiedView: View {
 
     func showReviewPromptIfLaunchedEnoughTimes() {
         launchCount += 1
-        if launchCount > 2 && !hasReviewBeenPrompted {
+        guard launchCount > 2, !hasReviewBeenPrompted else { return }
+        Task {
+            // Don't interrupt startup-to-find: wait until the app has settled, and only prompt
+            // once data is loaded and nothing else is in the way.
+            try? await Task.sleep(for: .seconds(8))
+            guard authenticator.isReady, !authenticator.isAuthenticating, !oasis.isShowing else { return }
             requestReview()
             hasReviewBeenPrompted = true
         }

--- a/CiRCLES.xcodeproj/project.pbxproj
+++ b/CiRCLES.xcodeproj/project.pbxproj
@@ -849,7 +849,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 108.1;
+				MARKETING_VERSION = 108.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.CiRCLES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
@@ -892,7 +892,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 108.1;
+				MARKETING_VERSION = 108.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.CiRCLES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
@@ -923,7 +923,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 108.1;
+				MARKETING_VERSION = 108.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.CiRCLES.ShareWithCiRCLES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -951,7 +951,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 108.1;
+				MARKETING_VERSION = 108.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.CiRCLES.ShareWithCiRCLES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/RADiUS/Catalog/User.swift
+++ b/RADiUS/Catalog/User.swift
@@ -31,7 +31,7 @@ public class User {
     public static func urlRequestForUserAPI(endpoint: String, authToken: OpenIDToken) -> URLRequest {
         let endpoint = URL(string: "\(circleMsAPIEndpoint)/User/\(endpoint)/")!
 
-        var request = URLRequest(url: endpoint)
+        var request = URLRequest(url: endpoint, timeoutInterval: circleMsAPITimeout)
         request.httpMethod = "POST"
         request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
 

--- a/RADiUS/Catalog/WebCatalog.swift
+++ b/RADiUS/Catalog/WebCatalog.swift
@@ -62,7 +62,11 @@ public class WebCatalog {
         }
 
         if let endpoint = endpointComponents.url {
-            var request = URLRequest(url: endpoint, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: circleMsAPITimeout)
+            var request = URLRequest(
+                url: endpoint,
+                cachePolicy: .returnCacheDataElseLoad,
+                timeoutInterval: circleMsAPITimeout
+            )
             request.httpMethod = "POST"
             request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
             return request

--- a/RADiUS/Catalog/WebCatalog.swift
+++ b/RADiUS/Catalog/WebCatalog.swift
@@ -62,7 +62,7 @@ public class WebCatalog {
         }
 
         if let endpoint = endpointComponents.url {
-            var request = URLRequest(url: endpoint, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: 2.0)
+            var request = URLRequest(url: endpoint, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: circleMsAPITimeout)
             request.httpMethod = "POST"
             request.setValue("Bearer \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
             return request

--- a/RADiUS/Endpoints.swift
+++ b/RADiUS/Endpoints.swift
@@ -19,8 +19,6 @@ public let circleMsCancelURLSchema: String = """
 circles-app:/?error=access_denied&error_description=user%20access%20denied&state=auth
 """
 
-// Network timeouts. Kept short enough that a dead/captive network fails fast instead of hanging
-// on the default 60s, but long enough not to spuriously fail on a slow venue connection.
 public let circleMsAPITimeout: TimeInterval = 10.0
 public let circleMsTokenTimeout: TimeInterval = 15.0
 public let circleMsHeadTimeout: TimeInterval = 5.0

--- a/RADiUS/Endpoints.swift
+++ b/RADiUS/Endpoints.swift
@@ -18,3 +18,9 @@ public let circleMsAPIEndpoint: URL = URL(string: "https://api1.circle.ms")! // 
 public let circleMsCancelURLSchema: String = """
 circles-app:/?error=access_denied&error_description=user%20access%20denied&state=auth
 """
+
+// Network timeouts. Kept short enough that a dead/captive network fails fast instead of hanging
+// on the default 60s, but long enough not to spuriously fail on a slow venue connection.
+public let circleMsAPITimeout: TimeInterval = 10.0
+public let circleMsTokenTimeout: TimeInterval = 15.0
+public let circleMsHeadTimeout: TimeInterval = 5.0


### PR DESCRIPTION
Audited the app for battery, performance, and auth/network handling, then implemented the highest-impact, lowest-risk tier of fixes. Each commit is self-contained and compiles cleanly (`** BUILD SUCCEEDED **` on the iOS simulator).

## Goals
1. **Fast as heck** — cut main-thread work, redundant scans, and unbounded memory growth.
2. **Reliable offline / connected-but-broken** — the on-disk catalog must always load and stay browsable.
3. **Quick startup → find a circle** — don't block the first usable map behind bulk loads.

## What changed

### Offline & auth reliability (`f926b09`)
- **Decouple `isReady` from Reachability.** A new synchronous `Authenticator.bootstrap()` restores credentials and marks the app ready at launch regardless of connectivity, so it can no longer hang forever on the loading screen when Reachability is `nil` / fails to fire. Callbacks now only update `onlineState`. `Events.updateActiveEvent` also resolves `.undetermined` to on-disk data.
- **Status-code-aware auth.** Token refresh inspects `HTTPURLResponse` and forces re-login only on a decisive 4xx; transient/timeout/captive-portal failures keep the existing token. Token timeout raised 2s → 15s.
- **Credential-safe.** `resetAuthentication()` no longer calls `keychain.removeAll()` (preserves the OpenID client config + refresh token); `useOfflineAuthenticationToken()` no longer overwrites a valid restored token.
- **Expired-while-offline browsing.** No forced, non-dismissable login wall just because the access token expired — attempt a silent refresh, escalate only on real rejection.
- **Timeouts everywhere** (centralized constants) on every previously-unbounded request — no more 60s captive-portal hangs.

### Performance & battery (`f926b09`)
- **Debounced search** (`.task(id:)`) — one query per search instead of ~5 per keystroke.
- **No animation on bulk list/grid/search array swaps**; gated the StoreKit review prompt behind an app-settled check.
- **Read-only PRAGMA tuning** on the catalog connections; **per-download background `URLSession`s invalidated**; background token refresh skips the network when the token is fresh.

### Lazy + bounded images (`0c290f2`, `3e67223`)
- Replaced the load-everything-into-RAM blob dictionaries with lightweight presence sets + **lazy per-id/name SQLite reads**, so the first usable map no longer waits for the whole common-image table.
- Replaced the unbounded decoded-image dictionary with a **bounded `NSCache`** (64 MB), breaking the jetsam → cold-restart cycle. The `CircleCutImage` overlay presence check is now an O(1) set lookup.
- Indexed the image DB so the new per-id/name lookups stay indexed (never degrade to full scans).

### Indexes + FTS5 (`45c4dba`, `2aae321`)
- Build secondary indexes on hot filter columns (`blockId`, `genreId`, `day`, `(day, blockId)`, `WCId`, `mapId`) and an **FTS5 trigram** search table once at download time (off-main). Filters become indexed lookups; substring search is index-backed with a LIKE fallback for short terms / catalogs without FTS.
- Push circle hydration ordering into SQL (`ORDER BY`) instead of a main-thread Swift sort.

## Verification
All commits build cleanly on the simulator. This environment can build/launch but **can't tap the UI**, so behavior wasn't runtime-verified. Recommend a manual pass on:
- Visit checkmarks / favorite overlays render correctly (overlay now gates on `hasCircleImage` rather than decoding an image).
- First launch on an already-downloaded event: the one-time index/FTS build runs during load; confirm it completes and search returns results (FTS ≥3 chars, LIKE for 2).

## Deliberately deferred
- **Full off-main `circles()` hydration** — needs `ComiketCircle` et al. to be `Sendable`; they're mutable classes, so the safe SQL-ordering half was done and the value-type DTO refactor left as follow-up.
- **Per-cell `@Query` → shared visited-ID set**, **MapScrollView zoom throttle**, **off-main image decode/downsampling** — real wins but behavior-sensitive; worth doing with a manual test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)