### PR TITLE
Refresh event list on Event Data Management open and pull to refresh

### DIFF
--- a/App/Classes/Events.swift
+++ b/App/Classes/Events.swift
@@ -109,9 +109,7 @@ class Events {
             if let cachedEventData = WebCatalog.cachedEvents() {
                 setEventData(cachedEventData)
                 Task {
-                    if let freshEventData = await WebCatalog.events(authToken: authToken) {
-                        self.setEventData(freshEventData)
-                    }
+                    await self.refresh(authToken: authToken)
                 }
             } else {
                 // Fetch event data from API
@@ -121,6 +119,25 @@ class Events {
             }
         }
 
+        applyEventData()
+    }
+
+    /// Re-fetches the event list from the API and applies it when the request succeeds, so that
+    /// events added since the last fetch show up without needing to reinstall the app.
+    /// Previously loaded data is left untouched when the request fails.
+    @MainActor
+    @discardableResult
+    func refresh(authToken: OpenIDToken) async -> Bool {
+        guard let freshEventData = await WebCatalog.refreshedEvents(authToken: authToken) else {
+            return false
+        }
+        setEventData(freshEventData)
+        applyEventData()
+        return true
+    }
+
+    @MainActor
+    private func applyEventData() {
         guard let eventData, let latestEvent else { return }
 
         // Set active event to latest event if active event number is not specified

--- a/App/Views/More/EventDataView.swift
+++ b/App/Views/More/EventDataView.swift
@@ -95,6 +95,11 @@ struct EventDataView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             await refresh()
+            await reloadEventList()
+        }
+        .refreshable {
+            await reloadEventList()
+            await refresh()
         }
         .alert(
             "Alerts.SwitchEvent.Title",
@@ -132,6 +137,11 @@ struct EventDataView: View {
 
     private var hasOtherEvents: Bool {
         (inactiveDownloadedEvents?.isEmpty == false) || (downloadableEvents?.isEmpty == false)
+    }
+
+    private func reloadEventList() async {
+        guard isOnline, let token = authenticator.token else { return }
+        await events.refresh(authToken: token)
     }
 
     private func refresh() async {

--- a/RADiUS/Catalog/WebCatalog.swift
+++ b/RADiUS/Catalog/WebCatalog.swift
@@ -12,13 +12,24 @@ public class WebCatalog {
     public static let eventCacheKey = "WebCatalog.Events"
 
     public static func events(authToken: OpenIDToken) async -> WebCatalogEvent.Response? {
-        let request = urlRequestForWebCatalogAPI(endpoint: "GetEventList", authToken: authToken)
+        return await refreshedEvents(authToken: authToken) ?? cachedEvents()
+    }
+
+    /// Fetches the event list from the API, bypassing the local URL cache so that newly added events
+    /// are always picked up. Returns `nil` when the request fails, letting callers tell a successful
+    /// refresh apart from a fallback to previously stored data.
+    public static func refreshedEvents(authToken: OpenIDToken) async -> WebCatalogEvent.Response? {
+        let request = urlRequestForWebCatalogAPI(
+            endpoint: "GetEventList",
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            authToken: authToken
+        )
         if let (data, _) = try? await URLSession.shared.data(for: request),
            let events = try? JSONDecoder().decode(WebCatalogEvent.self, from: data) {
             UserDefaults.standard.set(data, forKey: eventCacheKey)
             return events.response
         }
-        return cachedEvents()
+        return nil
     }
 
     public static func cachedEvents() -> WebCatalogEvent.Response? {
@@ -49,6 +60,7 @@ public class WebCatalog {
         endpoint: String,
         method _: String = "POST",
         parameters: [String: String] = [:],
+        cachePolicy: URLRequest.CachePolicy = .returnCacheDataElseLoad,
         authToken: OpenIDToken
     ) -> URLRequest {
         var endpointComponents = URLComponents(string: "\(circleMsAPIEndpoint)/WebCatalog/\(endpoint)")!
@@ -64,7 +76,7 @@ public class WebCatalog {
         if let endpoint = endpointComponents.url {
             var request = URLRequest(
                 url: endpoint,
-                cachePolicy: .returnCacheDataElseLoad,
+                cachePolicy: cachePolicy,
                 timeoutInterval: circleMsAPITimeout
             )
             request.httpMethod = "POST"


### PR DESCRIPTION
## Problem

A user reported that a newly released event never appeared in the event list, and that deleting and reinstalling the app was the only thing that fixed it.

Two layers of caching combined to cause this:

1. **The event list was fetched at most once per app launch.** `Events.prepare()` is guarded by `if eventData == nil`, so once the list was loaded it was never re-fetched for the lifetime of the process. Backgrounding the app, switching events, re-authenticating and the "Update data" button all left the list untouched.
2. **The request preferred cached data over the server.** `urlRequestForWebCatalogAPI` hardcoded `cachePolicy: .returnCacheDataElseLoad`, which returns a cached response without revalidating whenever one exists.

The stored copy in `UserDefaults` was also served first on launch, with the background refresh going through layer 2 above. Since neither cache is cleared by anything the user can reach in the app, a stale list could persist indefinitely.

## Changes

**`RADiUS/Catalog/WebCatalog.swift`**
- Added a `cachePolicy` parameter to `urlRequestForWebCatalogAPI`, defaulting to the existing `.returnCacheDataElseLoad` so other endpoints are unaffected.
- Split out `refreshedEvents(authToken:)`, which fetches the event list with `.reloadIgnoringLocalCacheData` and returns `nil` on failure, so callers can distinguish a successful refresh from a fallback to stale data.
- `events(authToken:)` is now `refreshedEvents(...) ?? cachedEvents()`, keeping the stored copy as an offline fallback.

**`App/Classes/Events.swift`**
- Extracted the active-event derivation out of `prepare()` into `applyEventData()`.
- Added `refresh(authToken:)`, which re-fetches the list and applies it only when the request succeeds, leaving previously loaded data intact on failure. It also re-derives `isActiveEventLatest` and `activeEvent`, which the old background refresh did not do.
- `prepare()`'s background refresh now goes through `refresh(authToken:)`.

**`App/Views/More/EventDataView.swift`**
- Reload the event list in `.task`, so it updates every time the screen is opened.
- Added `.refreshable` for pull to refresh.
- Both go through `reloadEventList()`, which no-ops when offline or unauthenticated.

## Notes

- `refresh(authToken:)` never changes `activeEventNumber`, so the active event's local database is not disturbed. All local database paths key off `event.number`; `event.id` is only used as the download API's `event_id` parameter, so correcting it from a fresh list is safe.
- When a new event appears, `isActiveEventLatest` now flips to `false` for a user still on the previously latest event, which hides the Favorites tab. This matches the existing intent of that flag and already happened on the next cold launch — it just happens on refresh now too.
- Offline behaviour is unchanged: the request fails, `refreshedEvents` returns `nil`, and the stored list continues to be used.

## Testing

Not built or run — no Xcode toolchain is available in this environment, so the changes are unverified beyond review. Worth confirming on device that pull to refresh picks up a newly added event and that offline mode still shows the stored list.

---
_Generated by [Claude Code](https://claude.ai/code/session_013GdHtUPPcMQDth8gmMduiF)_