### PR TITLE
Fall back to cached favorites when the favorites API request fails

### DIFF
--- a/App/Actors/FavoritesActor.swift
+++ b/App/Actors/FavoritesActor.swift
@@ -20,33 +20,30 @@ actor FavoritesActor {
 
         var wcIDMappedItems: [Int: UserFavorites.Response.FavoriteItem] = [:]
         var items: [UserFavorites.Response.FavoriteItem] = []
-        if let (data, _) = try? await URLSession.shared.data(for: request) {
-            if let favorites = try? JSONDecoder().decode(UserFavorites.self, from: data) {
-                items = favorites.response.list.sorted(by: {
-                    $0.favorite.color.rawValue < $1.favorite.color.rawValue
-                })
-                for favorite in items {
-                    wcIDMappedItems[favorite.circle.webCatalogID] = favorite
-                }
-                try? modelContext.transaction {
-                    try? modelContext.delete(model: CirclesFavorite.self)
-                    wcIDMappedItems.keys.forEach { webCatalogID in
-                        if let favoriteItem = wcIDMappedItems[webCatalogID] {
-                            let favorite = CirclesFavorite(
-                                webCatalogID: webCatalogID,
-                                favoriteItem: favoriteItem
-                            )
-                            modelContext.insert(favorite)
-                        }
+        if let (data, response) = try? await URLSession.shared.data(for: request),
+           (response as? HTTPURLResponse).map({ (200..<300).contains($0.statusCode) }) ?? true,
+           let favorites = try? JSONDecoder().decode(UserFavorites.self, from: data) {
+            items = favorites.response.list.sorted(by: {
+                $0.favorite.color.rawValue < $1.favorite.color.rawValue
+            })
+            for favorite in items {
+                wcIDMappedItems[favorite.circle.webCatalogID] = favorite
+            }
+            try? modelContext.transaction {
+                try? modelContext.delete(model: CirclesFavorite.self)
+                wcIDMappedItems.keys.forEach { webCatalogID in
+                    if let favoriteItem = wcIDMappedItems[webCatalogID] {
+                        let favorite = CirclesFavorite(
+                            webCatalogID: webCatalogID,
+                            favoriteItem: favoriteItem
+                        )
+                        modelContext.insert(favorite)
                     }
-                    try? modelContext.save()
                 }
+                try? modelContext.save()
             }
-        } else if let cachedFavorites: [CirclesFavorite] = try? modelContext.fetch(FetchDescriptor<CirclesFavorite>()) {
-            items = cachedFavorites.map({ $0.favoriteItem() })
-            for favorite in cachedFavorites {
-                wcIDMappedItems[favorite.webCatalogID] = favorite.favoriteItem()
-            }
+        } else {
+            return cached()
         }
         return (items, wcIDMappedItems)
     }


### PR DESCRIPTION
## Summary

Fixes favorites appearing empty after an app restart (user report: 設定したお気に入りのサークル情報がアプリを再起動させたら表示されなくなりました).

`FavoritesActor.all()` only fell back to the SwiftData cache when `URLSession` itself threw. When the request succeeded at the transport level but the server returned an error response — e.g. an expired access token right after launch, before the token refresh completes — decoding failed silently and an empty list was returned, blanking out the favorites UI even though the cache was intact.

## Changes

- `FavoritesActor.all()` now returns `cached()` whenever the response is not a decodable 2xx result (network failure, error status code, or undecodable body), instead of returning an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MX2c4AATSowoqqGNTvuWs2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX2c4AATSowoqqGNTvuWs2)_